### PR TITLE
Fix SonarCloud path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,6 @@
 # Based on the appveyor.yml example at
 # https://www.appveyor.com/docs/lang/nodejs-iojs/
 
-# Test on both Windows Server 2012 (~Windows 8) and
-# Windows Server 2016 (~Windows 10)
-image:
-  - Visual Studio 2015
-  - Visual Studio 2017
-
 # Test against the latest version of this Node.js version
 environment:
   nodejs_version: "6"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.links.issue=https://github.com/dubious-developments/UnSHACLed/issues
 # =====================================================
 
 # SQ standard properties
-sonar.sources=./source
+sonar.sources=./src
 sonar.exclusions=node_modules/**
 sonar.tests=./test
 


### PR DESCRIPTION
We broke SonarCloud by renaming `source` to `src`. That also means that our Travis build is failing. Also, we need to demo our project today. 😱 This PR should fix the Travis build.