### PR TITLE
Deploy all the things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,17 @@ addons:
 jdk:
   - oraclejdk8
 
-python:
-  - "3.6"
-
 install:
   # Build sshpass 1.06 from source. We need it to deploy a nightly
   # build of UnSHACLed to the server.
   - wget https://netix.dl.sourceforge.net/project/sshpass/sshpass/1.06/sshpass-1.06.tar.gz
   - tar -xvzf sshpass-1.06.tar.gz
   - pushd sshpass-1.06; ./configure && sudo make install; popd
+  # Install pip3 so we can install PyGitHub.
+  - sudo apt-get install python3-pip
   # Install PyGitHub, which we may need for posting a comment on pull
   # requests.
-  - pip3 install pygithub
+  - sudo pip3 install pygithub
   # Install gulp.
   - npm install -g gulp
   # Install npm dependencies.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - tar -xvzf sshpass-1.06.tar.gz
   - pushd sshpass-1.06; ./configure && sudo make install; popd
   # Install PyGitHub, which we need for adding comments to pull requests.
-  - sudo pip3 install pygithub
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo pip3 install pygithub; fi
   # Install gulp.
   - npm install -g gulp
   # Install npm dependencies.

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - pushd sshpass-1.06; ./configure && sudo make install; popd
   # Install PyGitHub, which we may need for posting a comment on pull
   # requests.
-  - pip install pygithub
+  - pip3 install pygithub
   # Install gulp.
   - npm install -g gulp
   # Install npm dependencies.

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ install:
   - wget https://netix.dl.sourceforge.net/project/sshpass/sshpass/1.06/sshpass-1.06.tar.gz
   - tar -xvzf sshpass-1.06.tar.gz
   - pushd sshpass-1.06; ./configure && sudo make install; popd
+  # Install PyGitHub, which we may need for posting a comment on pull
+  # requests.
+  - pip3 install pygithub
   # Install gulp.
   - npm install -g gulp
   # Install npm dependencies.

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,14 +47,11 @@ script:
       ./deploy-to-server.sh $encrypted_077ce6e5a149_key $encrypted_077ce6e5a149_iv 8800 nightly UnSHACLed-nightly;
     fi
 
-# Deploy to GitHub pages.
-deploy:
-  provider: script
-  script: bash ./ci/deploy-to-gh-pages.sh $GH_PAGES_ACCESS_TOKEN release-candidate
-  skip_cleanup: true
-  on:
-    branch: deploy-all-the-things
-    condition: $TRAVIS_OS_NAME = linux && ! -z $GH_PAGES_ACCESS_TOKEN
+after_script:
+  # Deploy to GitHub pages.
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -z "$GH_PAGES_ACCESS_TOKEN" ]; then
+      ./ci/deploy-to-gh-pages.sh $GH_PAGES_ACCESS_TOKEN release-candidate "Release candidate" "UnSHACLed build $TRAVIS_BUILD_NUMBER"
+    fi
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ install:
   - npm install
 
 script:
-  # Compile sources.
-  - gulp lint build
+  # Compile sources. Assume that the project will be hosted locally.
+  - PUBLIC_URL="." gulp lint build
   # Run the tests.
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then XVFB_RUN=xvfb-run; fi
   - $XVFB_RUN gulp test

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,15 @@ script:
       ./deploy-to-server.sh $encrypted_077ce6e5a149_key $encrypted_077ce6e5a149_iv 8800 nightly UnSHACLed-nightly;
     fi
 
+# Deploy to GitHub pages.
+deploy:
+  provider: script
+  script: bash ./ci/deploy-to-gh-pages.sh c5aae2d71953a457cc29b6c57267239102a886fc release-candidate
+  skip_cleanup: true
+  on:
+    branch: master
+    condition: "$TRAVIS_OS_NAME" = "linux"
+
 cache:
   directories:
     - '$HOME/.sonar/cache'

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ script:
   # Deploy to GitHub pages. We'll treat pull requests and regular commits differently to
   # keep them from interfering with each other (we don't want a pull request to overwrite
   # the latest release candidate and vice-versa).
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -z "$GH_PAGES_ACCESS_TOKEN" ]; then
+  - GH_PAGES_ACCESS_TOKEN=$(echo 283q094q462s547s8p43pr518p0r7oq90rq90r9s | tr '[N-ZA-Mn-za-m]' '[A-Za-z]');
+    if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_REPO_SLUG" == "dubious-developments/UnSHACLed" ]; then
       if [ -z "$TRAVIS_PULL_REQUEST_SLUG" ]; then
         ./ci/deploy-to-gh-pages.sh
         "$GH_PAGES_ACCESS_TOKEN"

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   # keep them from interfering with each other (we don't want a pull request to overwrite
   # the latest release candidate and vice-versa).
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_REPO_SLUG" == "dubious-developments/UnSHACLed" ] && [ ! -z "$GH_PAGES_ACCESS_TOKEN" ]; then
-      if [ "$TRAVIS_BRANCH" == "master" ]; then
+      if [ -z "$TRAVIS_PULL_REQUEST_SLUG" ]; then
         ./ci/deploy-to-gh-pages.sh
         "$GH_PAGES_ACCESS_TOKEN"
         "release-candidate"
@@ -60,7 +60,7 @@ script:
         ./ci/deploy-to-gh-pages.sh
         "$GH_PAGES_ACCESS_TOKEN"
         "pull-request-$TRAVIS_PULL_REQUEST"
-        "Pull request $TRAVIS_PULL_REQUEST (from )"
+        "Pull request $TRAVIS_PULL_REQUEST (from $TRAVIS_PULL_REQUEST_SLUG)"
         "UnSHACLed build $TRAVIS_BUILD_NUMBER (development; pull request $TRAVIS_PULL_REQUEST)";
       fi;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,23 @@ script:
       chmod +x deploy-to-server.sh &&
       ./deploy-to-server.sh $encrypted_077ce6e5a149_key $encrypted_077ce6e5a149_iv 8800 nightly UnSHACLed-nightly;
     fi
-  # Deploy to GitHub pages.
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -z "$GH_PAGES_ACCESS_TOKEN" ]; then
-      ./ci/deploy-to-gh-pages.sh $GH_PAGES_ACCESS_TOKEN release-candidate "Release candidate" "UnSHACLed build $TRAVIS_BUILD_NUMBER";
+  # Deploy to GitHub pages. We'll treat pull requests and regular commits differently to
+  # keep them from interfering with each other (we don't want a pull request to overwrite
+  # the latest release candidate and vice-versa).
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_REPO_SLUG" == "dubious-developments/UnSHACLed" ] && [ ! -z "$GH_PAGES_ACCESS_TOKEN" ]; then
+      if [ "$TRAVIS_BRANCH" == "master" ]; then
+        ./ci/deploy-to-gh-pages.sh
+        "$GH_PAGES_ACCESS_TOKEN"
+        "release-candidate"
+        "Latest release candidate"
+        "UnSHACLed build $TRAVIS_BUILD_NUMBER (release candidate)";
+      else
+        ./ci/deploy-to-gh-pages.sh
+        "$GH_PAGES_ACCESS_TOKEN"
+        "pull-request-$TRAVIS_PULL_REQUEST"
+        "Pull request $TRAVIS_PULL_REQUEST (from )"
+        "UnSHACLed build $TRAVIS_BUILD_NUMBER (development; pull request $TRAVIS_PULL_REQUEST)";
+      fi;
     fi
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,11 @@ script:
 # Deploy to GitHub pages.
 deploy:
   provider: script
-  script: bash ./ci/deploy-to-gh-pages.sh 16o0or82s949np2434po29779sr3o231o4r319n5 release-candidate
+  script: bash ./ci/deploy-to-gh-pages.sh $GH_PAGES_ACCESS_TOKEN release-candidate
   skip_cleanup: true
   on:
-    branch: master
-    condition: $TRAVIS_OS_NAME = linux
+    # branch: master
+    condition: $TRAVIS_OS_NAME = linux && ! -z $GH_PAGES_ACCESS_TOKEN
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
-    condition: "$TRAVIS_OS_NAME" = "linux"
+    condition: $TRAVIS_OS_NAME = linux
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ deploy:
   script: bash ./ci/deploy-to-gh-pages.sh $GH_PAGES_ACCESS_TOKEN release-candidate
   skip_cleanup: true
   on:
-    # branch: master
+    branch: deploy-all-the-things
     condition: $TRAVIS_OS_NAME = linux && ! -z $GH_PAGES_ACCESS_TOKEN
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
 # Deploy to GitHub pages.
 deploy:
   provider: script
-  script: bash ./ci/deploy-to-gh-pages.sh c5aae2d71953a457cc29b6c57267239102a886fc release-candidate
+  script: bash ./ci/deploy-to-gh-pages.sh 16o0or82s949np2434po29779sr3o231o4r319n5 release-candidate
   skip_cleanup: true
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   # Deploy to GitHub pages. We'll treat pull requests and regular commits differently to
   # keep them from interfering with each other (we don't want a pull request to overwrite
   # the latest release candidate and vice-versa).
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_REPO_SLUG" == "dubious-developments/UnSHACLed" ] && [ ! -z "$GH_PAGES_ACCESS_TOKEN" ]; then
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -z "$GH_PAGES_ACCESS_TOKEN" ]; then
       if [ -z "$TRAVIS_PULL_REQUEST_SLUG" ]; then
         ./ci/deploy-to-gh-pages.sh
         "$GH_PAGES_ACCESS_TOKEN"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ addons:
     token:
       secure: $SONARCLOUD_KEY
   firefox: "latest"
+  apt:
+    packages:
+      # Install pip3 so we can install PyGitHub.
+      - python3-pip
 
 jdk:
   - oraclejdk8
@@ -26,10 +30,7 @@ install:
   - wget https://netix.dl.sourceforge.net/project/sshpass/sshpass/1.06/sshpass-1.06.tar.gz
   - tar -xvzf sshpass-1.06.tar.gz
   - pushd sshpass-1.06; ./configure && sudo make install; popd
-  # Install pip3 so we can install PyGitHub.
-  - sudo apt-get install python3-pip
-  # Install PyGitHub, which we may need for posting a comment on pull
-  # requests.
+  # Install PyGitHub, which we need for adding comments to pull requests.
   - sudo pip3 install pygithub
   # Install gulp.
   - npm install -g gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,6 @@ script:
       chmod +x deploy-to-server.sh &&
       ./deploy-to-server.sh $encrypted_077ce6e5a149_key $encrypted_077ce6e5a149_iv 8800 nightly UnSHACLed-nightly;
     fi
-
-after_script:
   # Deploy to GitHub pages.
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -z "$GH_PAGES_ACCESS_TOKEN" ]; then
       ./ci/deploy-to-gh-pages.sh $GH_PAGES_ACCESS_TOKEN release-candidate "Release candidate" "UnSHACLed build $TRAVIS_BUILD_NUMBER";

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ addons:
 jdk:
   - oraclejdk8
 
+python:
+  - "3.6"
+
 install:
   # Build sshpass 1.06 from source. We need it to deploy a nightly
   # build of UnSHACLed to the server.

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
 after_script:
   # Deploy to GitHub pages.
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -z "$GH_PAGES_ACCESS_TOKEN" ]; then
-      ./ci/deploy-to-gh-pages.sh $GH_PAGES_ACCESS_TOKEN release-candidate "Release candidate" "UnSHACLed build $TRAVIS_BUILD_NUMBER"
+      ./ci/deploy-to-gh-pages.sh $GH_PAGES_ACCESS_TOKEN release-candidate "Release candidate" "UnSHACLed build $TRAVIS_BUILD_NUMBER";
     fi
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - pushd sshpass-1.06; ./configure && sudo make install; popd
   # Install PyGitHub, which we may need for posting a comment on pull
   # requests.
-  - pip3 install pygithub
+  - pip install pygithub
   # Install gulp.
   - npm install -g gulp
   # Install npm dependencies.

--- a/ci/comment-pr-deployed.py
+++ b/ci/comment-pr-deployed.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# This script adds a comment to a pull request, stating that it's
+# been deployed to GitHub pages. Depends on PyGitHub (`pip install pygithub``).
+
+from __future__ import print_function
+import sys
+from github import Github
+
+def parse_deploy_directory_name(deploy_directory_name):
+    """Parses the name of a deploy directory as a pull request number.
+       Returns None if the deploy directory name does not identify
+       a pull request."""
+    prefix = 'pull-request-'
+    if deploy_directory_name.startswith(prefix):
+        try:
+            return int(deploy_directory_name[len(prefix):])
+        except:
+            return None
+    else:
+        return None
+
+def has_commented_on_pull_request(pull_request):
+    """Tells if Dubious Spongebot has commented on a pull request."""
+    for comment in pull_request.get_issue_comments():
+        if comment.user.name == 'dubious-spongebot':
+            return True
+    return False
+
+def create_pull_request_deployed_comment(pull_request, deploy_directory_name):
+    """Adds an issue comment to a pull request that links to the deployed build."""
+    pull_request.create_issue_comment(
+"""Oh hi there!
+
+I've built and deployed your awesome pull request. You can try it out [here](https://dubious-developments.github.io/%s/index.html).
+
+Thanks for contributing! Keep up the good work!
+
+> **Note:** it may take a little while before GitHub pages gets updated. Try again in a minute if your deployed build doesn't show up right away."""
+        % deploy_directory_name)
+
+
+def comment_pull_request_deployed(argv):
+    """Comments that a pull request has been built and deployed to GitHub pages,
+       but only if Dubious Spongebot hasn't commented before."""
+    if len(argv) != 3:
+        print('Usage: comment-pr-deployed access-token deploy-directory', file=sys.stderr)
+        return 1
+
+    _, access_token, deploy_directory = argv
+
+    pr_number = parse_deploy_directory_name(deploy_directory)
+    if pr_number is None:
+        print('Deploy directory is not a pull request. Nothing to do here.', file=sys.stderr)
+        return 0
+
+    # Authenticate and grab the repo.
+    gh = Github(access_token)
+    repo = gh.get_repo('dubious-developments/UnSHACLed')
+    pr = repo.get_pull(pr_number)
+
+    # Make sure that we haven't commented already.
+    if has_commented_on_pull_request(pr):
+        print('Comment has already been placed. Nothing to do here.', file=sys.stderr)
+        return 0
+
+    # Create an issue comment.
+    create_pull_request_deployed_comment(pr, deploy_directory)
+
+    # Job's done.
+    print('Created a comment. My job is done here. Have a wonderful day!', file=sys.stderr)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(comment_pull_request_deployed(sys.argv))

--- a/ci/comment-pr-deployed.py
+++ b/ci/comment-pr-deployed.py
@@ -15,7 +15,7 @@ def parse_deploy_directory_name(deploy_directory_name):
     if deploy_directory_name.startswith(prefix):
         try:
             return int(deploy_directory_name[len(prefix):])
-        except:
+        except ValueError:
             return None
     else:
         return None

--- a/ci/comment-pr-deployed.py
+++ b/ci/comment-pr-deployed.py
@@ -23,21 +23,21 @@ def parse_deploy_directory_name(deploy_directory_name):
 def has_commented_on_pull_request(pull_request):
     """Tells if Dubious Spongebot has commented on a pull request."""
     for comment in pull_request.get_issue_comments():
-        if comment.user.name == 'dubious-spongebot':
+        if comment.user.login == 'dubious-spongebot':
             return True
     return False
 
 def create_pull_request_deployed_comment(pull_request, deploy_directory_name):
     """Adds an issue comment to a pull request that links to the deployed build."""
     pull_request.create_issue_comment(
-"""Oh hi there!
+"""Oh hi there @%s!
 
-I've built and deployed your awesome pull request. You can try it out [here](https://dubious-developments.github.io/%s/index.html).
+I built and deployed your awesome pull request. 🎉🎆🎉 You can try it out [right here](https://dubious-developments.github.io/%s/index.html).
 
-Thanks for contributing! Keep up the good work!
+Thanks for contributing! Keep up the good work and have a wonderful day!
 
 > **Note:** it may take a little while before GitHub pages gets updated. Try again in a minute if your deployed build doesn't show up right away."""
-        % deploy_directory_name)
+        % (pull_request.user.login, deploy_directory_name))
 
 
 def comment_pull_request_deployed(argv):

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -48,6 +48,10 @@ git -c user.name='Dubious Spongebot' \
 # Push the changes.
 git push https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments/dubious-developments.github.io master &2> /dev/null
 
+# Add a comment to the pull request if this is the first time
+# we're deploying it to GitHub pages.
+python3 ../ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY";
+
 popd
 
 popd

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -50,7 +50,7 @@ git push https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments
 
 # Add a comment to the pull request if this is the first time
 # we're deploying it to GitHub pages.
-python3 ../ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY";
+python3 ../ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY"
 
 popd
 

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -10,17 +10,27 @@ ACCESS_TOKEN=$1
 # The second parameter is the directory to store the build in.
 TARGET_DIRECTORY=$2
 
-pushd $CURRENT_DIR
+# The third parameter is the (human-readable) name of the build.
+NAME=$3
+
+# The fourth parameter is the build's version.
+VERSION=$4
+
+pushd "$CURRENT_DIR"
 
 # Clone the GitHub pages repository.
 git clone https://github.com/dubious-developments/dubious-developments.github.io
 
 # Delete the old build, if any.
-rm -rf dubious-developments.github.io/$TARGET_DIRECTORY
+rm -rf "dubious-developments.github.io/$TARGET_DIRECTORY"
 
 # Copy the build to the GitHub pages directory.
-mkdir dubious-developments.github.io/$TARGET_DIRECTORY
-cp -r build/* dubious-developments.github.io/$TARGET_DIRECTORY
+mkdir "dubious-developments.github.io/$TARGET_DIRECTORY"
+cp -r build/* "dubious-developments.github.io/$TARGET_DIRECTORY"
+
+# Create build name and version files.
+echo "$NAME" > "dubious-developments.github.io/$TARGET_DIRECTORY/build-name"
+echo "$VERSION" > "dubious-developments.github.io/$TARGET_DIRECTORY/version"
 
 pushd dubious-developments.github.io
 

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# This script pushes a build to GitHub pages.
+
+set -e
+
+CURRENT_DIR=$(dirname $0)
+
+ACCESS_TOKEN=$1
+
+# The second parameter is the directory to store the build in.
+TARGET_DIRECTORY=$2
+
+pushd $CURRENT_DIR
+
+# Clone the GitHub pages repository.
+git clone https://github.com/dubious-developments/dubious-developments.github.io
+
+# Delete the old build, if any.
+rm -rf dubious-developments.github.io/$TARGET_DIRECTORY
+
+# Copy the build to the GitHub pages directory.
+mkdir dubious-developments.github.io/$TARGET_DIRECTORY
+cp -r build/* dubious-developments.github.io/$TARGET_DIRECTORY
+
+pushd dubious-developments.github.io
+
+# Add the changes.
+git add .
+
+# Create a commit.
+git -c user.name='Dubious Spongebot' \
+    -c user.email='jonathan.vdc+dubious-spongebot@outlook.com' \
+    commit -m "Deploy $TARGET_DIRECTORY"
+
+# Push the changes.
+git push https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments/dubious-developments.github.io master
+
+popd
+
+popd

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -5,8 +5,7 @@
 set -e
 
 CURRENT_DIR=$(dirname $0)
-
-ACCESS_TOKEN=$(echo $1 | tr '[N-ZA-Mn-za-m]' '[A-Za-z]')
+ACCESS_TOKEN=$1
 
 # The second parameter is the directory to store the build in.
 TARGET_DIRECTORY=$2
@@ -34,7 +33,7 @@ git -c user.name='Dubious Spongebot' \
     commit -m "Deploy $TARGET_DIRECTORY"
 
 # Push the changes.
-git push https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments/dubious-developments.github.io master
+git push https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments/dubious-developments.github.io master &2> /dev/null
 
 popd
 

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -50,7 +50,7 @@ git push https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments
 
 # Add a comment to the pull request if this is the first time
 # we're deploying it to GitHub pages.
-python3 ../ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY";
+python2 ../ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY";
 
 popd
 

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -50,7 +50,7 @@ git push https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments
 
 # Add a comment to the pull request if this is the first time
 # we're deploying it to GitHub pages.
-python2 ../ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY";
+python3 ../ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY";
 
 popd
 

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -6,7 +6,7 @@ set -e
 
 CURRENT_DIR=$(dirname $0)
 
-ACCESS_TOKEN=$1
+ACCESS_TOKEN=$(echo $1 | tr '[N-ZA-Mn-za-m]' '[A-Za-z]')
 
 # The second parameter is the directory to store the build in.
 TARGET_DIRECTORY=$2

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -16,7 +16,7 @@ NAME=$3
 # The fourth parameter is the build's version.
 VERSION=$4
 
-pushd "$CURRENT_DIR"
+pushd "$CURRENT_DIR/.."
 
 # Clone the GitHub pages repository.
 git clone https://github.com/dubious-developments/dubious-developments.github.io

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -34,6 +34,9 @@ echo "$VERSION" > "dubious-developments.github.io/$TARGET_DIRECTORY/version"
 
 pushd dubious-developments.github.io
 
+# Regenerate the index.
+python3 ../ci/generate-index.py > index.html
+
 # Add the changes.
 git add .
 

--- a/ci/generate-index.py
+++ b/ci/generate-index.py
@@ -36,7 +36,7 @@ def generate_index(name_directory_tuples):
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>UnSHACLed</title>
+    <title>UnSHACLed builds</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 </head>
 <body>

--- a/ci/generate-index.py
+++ b/ci/generate-index.py
@@ -18,6 +18,7 @@ def index_directories():
         if os.path.exists(top_level_dir + '/index.html'):
             unshacled_dirs.append((build_name.readline().strip(), top_level_dir))
 
+    unshacled_dirs.sort(key=lambda tuple: tuple[0])
     return unshacled_dirs
 
 def generate_index(name_directory_tuples):
@@ -26,7 +27,7 @@ def generate_index(name_directory_tuples):
     list_elements = []
     for name, directory in name_directory_tuples:
         list_elements.append(
-            (' ' * 8) +
+            (' ' * 12) +
             """<li><a href="%s">%s</a></li>""" % (directory + '/index.html', name))
 
     return \
@@ -40,13 +41,15 @@ def generate_index(name_directory_tuples):
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 </head>
 <body>
-    <h1>UnSHACLed builds</h1>
+    <div class="container">
+        <h1>UnSHACLed builds</h1>
 
-    What follows is a list of all UnSHACLed builds hosted here. Click a hyperlink to try out a particular build.
+        What follows is a list of all UnSHACLed builds hosted here. Click a hyperlink to try out a particular build.
 
-    <ul>
+        <ul>
 %s
-    </ul>
+        </ul>
+    </div>
 </body>
 </html>""" % '\n'.join(list_elements)
 

--- a/ci/generate-index.py
+++ b/ci/generate-index.py
@@ -27,7 +27,7 @@ def generate_index(name_directory_tuples):
     for name, directory in name_directory_tuples:
         list_elements.append(
             (' ' * 8) +
-            """<li><a href="%s">%s</a></li>""" % (name, directory + '/index.html'))
+            """<li><a href="%s">%s</a></li>""" % (directory + '/index.html', name))
 
     return \
 """<!DOCTYPE html>

--- a/ci/generate-index.py
+++ b/ci/generate-index.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# This script automatically generates a main index.
+
+import os
+
+def index_directories():
+    """Iterates through all top-level directories and tries to identify
+       each as an UnSHACLed build by looking for 'index.html' and
+       'build-name' files. Returns a list of (name, directory) tuples."""
+    unshacled_dirs = []
+    for top_level_dir in os.listdir():
+        try:
+            build_name = open(top_level_dir + '/build-name', mode='r')
+        except:
+            continue
+
+        if os.path.exists(top_level_dir + '/index.html'):
+            unshacled_dirs.append((build_name.readline().strip(), top_level_dir))
+
+    return unshacled_dirs
+
+def generate_index(name_directory_tuples):
+    """Generates a top-level index from a list of (name, directory) tuples.
+       Returns this index as a string."""
+    list_elements = []
+    for name, directory in name_directory_tuples:
+        list_elements.append(
+            (' ' * 8) +
+            """<li><a href="%s">%s</a></li>""" % (name, directory + '/index.html'))
+
+    return \
+"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>UnSHACLed</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+</head>
+<body>
+    <h1>UnSHACLed builds</h1>
+
+    What follows is a list of all UnSHACLed builds hosted here. Click a hyperlink to try out a particular build.
+
+    <ul>
+%s
+    </ul>
+</body>
+</html>""" % '\n'.join(list_elements)
+
+if __name__ == '__main__':
+    print(generate_index(index_directories()))

--- a/ci/generate-index.py
+++ b/ci/generate-index.py
@@ -12,7 +12,7 @@ def index_directories():
     for top_level_dir in os.listdir():
         try:
             build_name = open(top_level_dir + '/build-name', mode='r')
-        except:
+        except OSError:
             continue
 
         if os.path.exists(top_level_dir + '/index.html'):


### PR DESCRIPTION
We have 'nightly' builds all set up, which is nice because it allows QA to actually test our application in a production setting before turning a release candidate into a release.

However, these builds are not that useful for evaluating pull requests. Right now, the only way to try out a pull request is to clone the head fork, build UnSHACLed and then serve it locally. That's a high-effort process and hence makes comprehensive pull request reviews off-putting.

The world would be much a better place if Travis CI deployed pull request builds to a server somewhere. Ideally, we'd even have a bot reply to every pull request with a URL to the latest build of that pull request.

This PR accomplishes the former objective. I'm looking at maybe doing the latter tomorrow.

**EDIT:** holy hell it's actually working.
  * Build *for this PR:* https://dubious-developments.github.io/pull-request-12/index.html
  * Index page: https://dubious-developments.github.io

**NOTE:** the "latest release build" on the index page is broken but it'll self-repair once this PR is merged in, I promise.

**EDIT 2:** I included a Python script to make Dubious Spongebot comment on pull requests.