### PR TITLE
Make Spongebot upload coverage reports

### DIFF
--- a/ci/comment-pr-deployed.py
+++ b/ci/comment-pr-deployed.py
@@ -50,17 +50,17 @@ def generate_pull_request_deployed_comment(pull_request, deploy_directory_name):
     salutation = random.choice(SALUTATIONS).format('@' + pull_request.user.login)
     valediction = random.choice(VALEDICTIONS)
 
-    message_format = """%s
+    message_format = """{0}
 
 I built and deployed your pull request. 🎉🎆🎉
-You can try it out [right here](https://dubious-developments.github.io/%s/index.html).
-If you're looking for the coverage report, that's [here](https://dubious-developments.github.io/%s/coverage/index.html).
+You can try it out [here](https://dubious-developments.github.io/{1}/index.html).
+If you're looking for the coverage report, that's [right here](https://dubious-developments.github.io/{1}/coverage/index.html).
 
-%s
+{2}
 
 > **Note:** it may take a little while before GitHub pages gets updated. Try again in a minute if your deployed build doesn't show up right away."""
 
-    return message_format % (salutation, deploy_directory_name, valediction)
+    return message_format.format(salutation, deploy_directory_name, valediction)
 
 def create_pull_request_deployed_comment(pull_request, deploy_directory_name):
     """Adds an issue comment to a pull request that links to the deployed build."""

--- a/ci/comment-pr-deployed.py
+++ b/ci/comment-pr-deployed.py
@@ -52,7 +52,9 @@ def generate_pull_request_deployed_comment(pull_request, deploy_directory_name):
 
     message_format = """%s
 
-I built and deployed your pull request. 🎉🎆🎉 You can try it out [right here](https://dubious-developments.github.io/%s/index.html).
+I built and deployed your pull request. 🎉🎆🎉
+You can try it out [right here](https://dubious-developments.github.io/%s/index.html).
+If you're looking for the coverage report, that's [here](https://dubious-developments.github.io/%s/coverage/index.html).
 
 %s
 

--- a/ci/comment-pr-deployed.py
+++ b/ci/comment-pr-deployed.py
@@ -5,6 +5,7 @@
 
 from __future__ import print_function
 import sys
+import random
 from github import Github
 
 def parse_deploy_directory_name(deploy_directory_name):
@@ -27,17 +28,37 @@ def has_commented_on_pull_request(pull_request):
             return True
     return False
 
+# Spongebot Squarepants' greetings.
+SALUTATIONS = [
+    """Oh hi there {0}!""",
+    """I did not hit her, it's not true! It's bullshit! I did not hit her! *I did naaaahht.* Oh hi {0}.""",
+    """Oh hi {0}. I didn't know it was you.""",
+    """Ha ha ha. What a story, {0}."""
+]
+
+# Things Spongebot Squarepants may say to bid you farewell.
+VALEDICTIONS = [
+    """Thanks for contributing! Keep up the good work and have a wonderful day!""",
+    """You're my favorite customer. Buh-bye.""",
+    """This is a beautiful pull request! You included all the code. Good thinking!""",
+    """You think about everything. Ha ha ha."""
+]
+
 def generate_pull_request_deployed_comment(pull_request, deploy_directory_name):
     """Generates the body of the comment that is posted when a pull request
        has been deployed to GitHub pages."""
-    return """Oh hi there @%s!
+    salutation = random.choice(SALUTATIONS).format('@' + pull_request.user.login)
+    valediction = random.choice(VALEDICTIONS)
 
-I built and deployed your awesome pull request. 🎉🎆🎉 You can try it out [right here](https://dubious-developments.github.io/%s/index.html).
+    message_format = """%s
 
-Thanks for contributing! Keep up the good work and have a wonderful day!
+I built and deployed your pull request. 🎉🎆🎉 You can try it out [right here](https://dubious-developments.github.io/%s/index.html).
 
-> **Note:** it may take a little while before GitHub pages gets updated. Try again in a minute if your deployed build doesn't show up right away.""" \
-        % (pull_request.user.login, deploy_directory_name)
+%s
+
+> **Note:** it may take a little while before GitHub pages gets updated. Try again in a minute if your deployed build doesn't show up right away."""
+
+    return message_format % (salutation, deploy_directory_name, valediction)
 
 def create_pull_request_deployed_comment(pull_request, deploy_directory_name):
     """Adds an issue comment to a pull request that links to the deployed build."""

--- a/ci/comment-pr-deployed.py
+++ b/ci/comment-pr-deployed.py
@@ -27,24 +27,36 @@ def has_commented_on_pull_request(pull_request):
             return True
     return False
 
-def create_pull_request_deployed_comment(pull_request, deploy_directory_name):
-    """Adds an issue comment to a pull request that links to the deployed build."""
-    pull_request.create_issue_comment(
-"""Oh hi there @%s!
+def generate_pull_request_deployed_comment(pull_request, deploy_directory_name):
+    """Generates the body of the comment that is posted when a pull request
+       has been deployed to GitHub pages."""
+    return """Oh hi there @%s!
 
 I built and deployed your awesome pull request. 🎉🎆🎉 You can try it out [right here](https://dubious-developments.github.io/%s/index.html).
 
 Thanks for contributing! Keep up the good work and have a wonderful day!
 
-> **Note:** it may take a little while before GitHub pages gets updated. Try again in a minute if your deployed build doesn't show up right away."""
-        % (pull_request.user.login, deploy_directory_name))
+> **Note:** it may take a little while before GitHub pages gets updated. Try again in a minute if your deployed build doesn't show up right away.""" \
+        % (pull_request.user.login, deploy_directory_name)
+
+def create_pull_request_deployed_comment(pull_request, deploy_directory_name):
+    """Adds an issue comment to a pull request that links to the deployed build."""
+    pull_request.create_issue_comment(
+        generate_pull_request_deployed_comment(
+            pull_request,
+            deploy_directory_name))
 
 
 def comment_pull_request_deployed(argv):
     """Comments that a pull request has been built and deployed to GitHub pages,
        but only if Dubious Spongebot hasn't commented before."""
+    is_dry_run = False
+    if len(argv) > 1 and argv[1] == '-d':
+        argv = [argv[0]] + argv[2:]
+        is_dry_run = True
+
     if len(argv) != 3:
-        print('Usage: comment-pr-deployed access-token deploy-directory', file=sys.stderr)
+        print('Usage: comment-pr-deployed [-d] access-token deploy-directory', file=sys.stderr)
         return 1
 
     _, access_token, deploy_directory = argv
@@ -62,10 +74,15 @@ def comment_pull_request_deployed(argv):
     # Make sure that we haven't commented already.
     if has_commented_on_pull_request(pr):
         print('Comment has already been placed. Nothing to do here.', file=sys.stderr)
-        return 0
+        if not is_dry_run:
+            return 0
 
     # Create an issue comment.
-    create_pull_request_deployed_comment(pr, deploy_directory)
+    if is_dry_run:
+        print('Would post this:')
+        print(generate_pull_request_deployed_comment(pr, deploy_directory))
+    else:
+        create_pull_request_deployed_comment(pr, deploy_directory)
 
     # Job's done.
     print('Created a comment. My job is done here. Have a wonderful day!', file=sys.stderr)

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -27,6 +27,7 @@ rm -rf "dubious-developments.github.io/$TARGET_DIRECTORY"
 # Copy the build and the coverage to the GitHub pages directory.
 mkdir "dubious-developments.github.io/$TARGET_DIRECTORY"
 cp -r build/* "dubious-developments.github.io/$TARGET_DIRECTORY"
+mkdir "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"
 cp -r coverage/Firefox*/* "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"
 
 # Create build name and version files.

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -24,9 +24,10 @@ git clone https://github.com/dubious-developments/dubious-developments.github.io
 # Delete the old build, if any.
 rm -rf "dubious-developments.github.io/$TARGET_DIRECTORY"
 
-# Copy the build to the GitHub pages directory.
+# Copy the build and the coverage to the GitHub pages directory.
 mkdir "dubious-developments.github.io/$TARGET_DIRECTORY"
 cp -r build/* "dubious-developments.github.io/$TARGET_DIRECTORY"
+cp -r coverage/Firefox*/* "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"
 
 # Create build name and version files.
 echo "$NAME" > "dubious-developments.github.io/$TARGET_DIRECTORY/build-name"


### PR DESCRIPTION
Coverage reports are super useful for evaluating pull requests. If merged in, this PR will make Spongebot upload them to GitHub pages.