### PR TITLE
Extend Spongebot to maintain forks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ src/**/*.js
 
 # npm package lock
 package-lock.json
+
+# Python bytecode cache
+__pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,20 +56,8 @@ script:
   # keep them from interfering with each other (we don't want a pull request to overwrite
   # the latest release candidate and vice-versa).
   - GH_PAGES_ACCESS_TOKEN=$(echo 283q094q462s547s8p43pr518p0r7oq90rq90r9s | tr '[N-ZA-Mn-za-m]' '[A-Za-z]');
-    if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_REPO_SLUG" == "dubious-developments/UnSHACLed" ]; then
-      if [ -z "$TRAVIS_PULL_REQUEST_SLUG" ]; then
-        ./ci/deploy-to-gh-pages.sh
-        "$GH_PAGES_ACCESS_TOKEN"
-        "release-candidate"
-        "Latest release candidate"
-        "UnSHACLed build $TRAVIS_BUILD_NUMBER (release candidate)";
-      else
-        ./ci/deploy-to-gh-pages.sh
-        "$GH_PAGES_ACCESS_TOKEN"
-        "pull-request-$TRAVIS_PULL_REQUEST"
-        "Pull request $TRAVIS_PULL_REQUEST (from $TRAVIS_PULL_REQUEST_SLUG)"
-        "UnSHACLed build $TRAVIS_BUILD_NUMBER (development; pull request $TRAVIS_PULL_REQUEST)";
-      fi;
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      python3 ci/deploy-to-gh-pages.py "$GH_PAGES_ACCESS_TOKEN";
     fi
 
 cache:

--- a/ci/comment-pr-deployed.py
+++ b/ci/comment-pr-deployed.py
@@ -5,73 +5,15 @@
 
 from __future__ import print_function
 import sys
-import random
 from github import Github
-
-def parse_deploy_directory_name(deploy_directory_name):
-    """Parses the name of a deploy directory as a pull request number.
-       Returns None if the deploy directory name does not identify
-       a pull request."""
-    prefix = 'pull-request-'
-    if deploy_directory_name.startswith(prefix):
-        try:
-            return int(deploy_directory_name[len(prefix):])
-        except ValueError:
-            return None
-    else:
-        return None
-
-def has_commented_on_pull_request(pull_request):
-    """Tells if Dubious Spongebot has commented on a pull request."""
-    for comment in pull_request.get_issue_comments():
-        if comment.user.login == 'dubious-spongebot':
-            return True
-    return False
-
-# Spongebot Squarepants' greetings.
-SALUTATIONS = [
-    """Oh hi there {0}!""",
-    """I did not hit her, it's not true! It's bullshit! I did not hit her! *I did naaaahht.* Oh hi {0}.""",
-    """Oh hi {0}. I didn't know it was you.""",
-    """Ha ha ha. What a story, {0}."""
-]
-
-# Things Spongebot Squarepants may say to bid you farewell.
-VALEDICTIONS = [
-    """Thanks for contributing! Keep up the good work and have a wonderful day!""",
-    """You're my favorite customer. Buh-bye.""",
-    """This is a beautiful pull request! You included all the code. Good thinking!""",
-    """You think about everything. Ha ha ha."""
-]
-
-def generate_pull_request_deployed_comment(pull_request, deploy_directory_name):
-    """Generates the body of the comment that is posted when a pull request
-       has been deployed to GitHub pages."""
-    salutation = random.choice(SALUTATIONS).format('@' + pull_request.user.login)
-    valediction = random.choice(VALEDICTIONS)
-
-    message_format = """{0}
-
-I built and deployed your pull request. 🎉🎆🎉
-You can try it out [here](https://dubious-developments.github.io/{1}/index.html).
-If you're looking for the coverage report, that's [right here](https://dubious-developments.github.io/{1}/coverage/index.html).
-
-{2}
-
-> **Note:** it may take a little while before GitHub pages gets updated. Try again in a minute if your deployed build doesn't show up right away."""
-
-    return message_format.format(salutation, deploy_directory_name, valediction)
-
-def create_pull_request_deployed_comment(pull_request, deploy_directory_name):
-    """Adds an issue comment to a pull request that links to the deployed build."""
-    pull_request.create_issue_comment(
-        generate_pull_request_deployed_comment(
-            pull_request,
-            deploy_directory_name))
-
+from spongebot import \
+    create_pull_request_deployed_comment, \
+    parse_deploy_directory_name, \
+    generate_pull_request_deployed_comment, \
+    has_commented_on_pull_request
 
 def comment_pull_request_deployed(argv):
-    """Comments that a pull request has been built and deployed to GitHub pages,
+    """Comments that a pulparse_depll request has been built and deployed to GitHub pages,
        but only if Dubious Spongebot hasn't commented before."""
     is_dry_run = False
     if len(argv) > 1 and argv[1] == '-d':

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+from __future__ import print_function
+import os
+import subprocess
+import sys
+
+# This script is basically just a fancy wrapper around
+# 'deploy-to-gh-pages.sh' that takes fewer parameters.
+
+def main(argv):
+    """Deploys to GitHub pages."""
+    if len(argv) > 1 and argv[1] == '-d':
+        is_dry_run = True
+        argv = [argv[0]] + argv[2:]
+    else:
+        is_dry_run = False
+
+    if len(argv) != 2:
+        print('Usage: deploy-to-gh-pages.py [-d] access-token', file=sys.stderr)
+        return 1
+
+    repo_slug = os.environ['TRAVIS_REPO_SLUG']
+    build_number = os.environ['TRAVIS_BUILD_NUMBER']
+    pr_slug = os.environ.get('TRAVIS_PULL_REQUEST_SLUG')
+    pr_number = os.environ.get('TRAVIS_PULL_REQUEST')
+    repo_owner, _ = repo_slug.split('/')
+
+    if repo_owner == 'dubious-developments':
+        if pr_slug is None:
+            deploy_dir = 'release-candidate'
+            build_name = 'Latest release candidate'
+            build_version_comment = 'release candidate'
+        else:
+            deploy_dir = 'pull-request-%s' % pr_number
+            build_name = 'Pull request %s' % pr_number
+            build_version_comment = 'development; pull request %s' % pr_number
+    else:
+        if pr_slug is None:
+            branch_name = os.environ['TRAVIS_BRANCH']
+            commit_hash = os.environ['TRAVIS_COMMIT']
+            deploy_dir = '%s/%s' % (repo_owner, branch_name)
+            build_name = 'Branch %s' % branch_name
+            build_version_comment = 'development; commit %s at %s' % (commit_hash, repo_slug)
+        else:
+            deploy_dir = '%s/pull-request-%s' % (repo_owner, pr_number)
+            build_name = 'Pull request %s' % pr_number
+            build_version_comment = 'development; pull request %s at %s' % (pr_number, repo_slug)
+
+    build_version = 'UnSHACLed build %s (%s)' % (build_number, build_version_comment)
+
+    token = argv[1]
+
+    command = (
+        os.path.realpath(__file__ + '/../deploy-to-gh-pages.sh'),
+        token,
+        deploy_dir,
+        build_name,
+        build_version
+    )
+
+    if is_dry_run:
+        print(' '.join('"%s"' % arg if ' ' in arg else arg for arg in command))
+
+    subprocess.call(*command)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -61,11 +61,11 @@ def main(argv):
         build_version
     ]
 
-    print('Running command: ' + ' '.join('"%s"' % arg if ' ' in arg else arg for arg in command), file=sys.stderr)
-
-    if not is_dry_run:
-        subprocess.call(command)
-    return 0
+    if is_dry_run:
+        print('Running command: ' + ' '.join('"%s"' % arg if ' ' in arg else arg for arg in command), file=sys.stderr)
+        return 0
+    else:
+        return subprocess.call(command)
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -26,7 +26,7 @@ def main(argv):
     pr_number = os.environ.get('TRAVIS_PULL_REQUEST')
     repo_owner, _ = repo_slug.split('/')
 
-    is_pr = pr_number.strip().lower() != 'false'
+    is_pr = pr_slug.strip() != ''
 
     if repo_owner == 'dubious-developments':
         if not is_pr:

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -26,7 +26,7 @@ def main(argv):
     pr_number = os.environ.get('TRAVIS_PULL_REQUEST')
     repo_owner, _ = repo_slug.split('/')
 
-    is_pr = pr_number != 'false'
+    is_pr = pr_number.strip().lower() != 'false'
 
     if repo_owner == 'dubious-developments':
         if not is_pr:

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -26,8 +26,10 @@ def main(argv):
     pr_number = os.environ.get('TRAVIS_PULL_REQUEST')
     repo_owner, _ = repo_slug.split('/')
 
+    is_pr = pr_number != 'false'
+
     if repo_owner == 'dubious-developments':
-        if pr_slug is None:
+        if not is_pr:
             deploy_dir = 'release-candidate'
             build_name = 'Latest release candidate'
             build_version_comment = 'release candidate'
@@ -36,7 +38,7 @@ def main(argv):
             build_name = 'Pull request %s' % pr_number
             build_version_comment = 'development; pull request %s' % pr_number
     else:
-        if pr_slug is None:
+        if not is_pr:
             branch_name = os.environ['TRAVIS_BRANCH']
             commit_hash = os.environ['TRAVIS_COMMIT']
             deploy_dir = '%s/%s' % (repo_owner, branch_name)

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -24,6 +24,7 @@ def main(argv):
     build_number = os.environ['TRAVIS_BUILD_NUMBER']
     pr_slug = os.environ.get('TRAVIS_PULL_REQUEST_SLUG')
     pr_number = os.environ.get('TRAVIS_PULL_REQUEST')
+    pr_origin = os.environ.get('TRAVIS_PULL_REQUEST_BRANCH')
     repo_owner, _ = repo_slug.split('/')
 
     is_pr = pr_slug.strip() != ''
@@ -35,7 +36,7 @@ def main(argv):
             build_version_comment = 'release candidate'
         else:
             deploy_dir = 'pull-request-%s' % pr_number
-            build_name = 'Pull request %s' % pr_number
+            build_name = 'Pull request %s (from %s)' % (pr_number, pr_origin)
             build_version_comment = 'development; pull request %s' % pr_number
     else:
         if not is_pr:
@@ -46,7 +47,7 @@ def main(argv):
             build_version_comment = 'development; commit %s at %s' % (commit_hash, repo_slug)
         else:
             deploy_dir = '%s/pull-request-%s' % (repo_owner, pr_number)
-            build_name = 'Pull request %s' % pr_number
+            build_name = 'Pull request %s (from %s)' % (pr_number, pr_origin)
             build_version_comment = 'development; pull request %s at %s' % (pr_number, repo_slug)
 
     build_version = 'UnSHACLed build %s (%s)' % (build_number, build_version_comment)

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -28,6 +28,8 @@ def main(argv):
 
     is_pr = pr_slug.strip() != ''
 
+    print('pr_slug: %s; is_pr: %s' % (pr_slug, is_pr), file=sys.stderr)
+
     if repo_owner == 'dubious-developments':
         if not is_pr:
             deploy_dir = 'release-candidate'

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -36,7 +36,7 @@ def main(argv):
             build_version_comment = 'release candidate'
         else:
             deploy_dir = 'pull-request-%s' % pr_number
-            build_name = 'Pull request %s (from %s)' % (pr_number, pr_origin)
+            build_name = 'Pull request %s (from %s-%s)' % (pr_number, pr_slug, pr_origin)
             build_version_comment = 'development; pull request %s' % pr_number
     else:
         if not is_pr:
@@ -47,7 +47,7 @@ def main(argv):
             build_version_comment = 'development; commit %s at %s' % (commit_hash, repo_slug)
         else:
             deploy_dir = '%s/pull-request-%s' % (repo_owner, pr_number)
-            build_name = 'Pull request %s (from %s)' % (pr_number, pr_origin)
+            build_name = 'Pull request %s (from %s-%s)' % (pr_number, pr_slug, pr_origin)
             build_version_comment = 'development; pull request %s at %s' % (pr_number, repo_slug)
 
     build_version = 'UnSHACLed build %s (%s)' % (build_number, build_version_comment)

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -51,18 +51,18 @@ def main(argv):
 
     token = argv[1]
 
-    command = (
+    command = [
         os.path.realpath(__file__ + '/../deploy-to-gh-pages.sh'),
         token,
         deploy_dir,
         build_name,
         build_version
-    )
+    ]
 
     if is_dry_run:
         print(' '.join('"%s"' % arg if ' ' in arg else arg for arg in command))
 
-    subprocess.call(*command)
+    subprocess.call(command)
     return 0
 
 if __name__ == '__main__':

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -43,7 +43,7 @@ def main(argv):
             branch_name = os.environ['TRAVIS_BRANCH']
             commit_hash = os.environ['TRAVIS_COMMIT']
             deploy_dir = '%s/%s' % (repo_owner, branch_name)
-            build_name = 'Branch %s' % branch_name
+            build_name = 'Branch \'%s\'' % branch_name
             build_version_comment = 'development; commit %s at %s' % (commit_hash, repo_slug)
         else:
             deploy_dir = '%s/pull-request-%s' % (repo_owner, pr_number)

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -28,8 +28,6 @@ def main(argv):
 
     is_pr = pr_slug.strip() != ''
 
-    print('pr_slug: %s; is_pr: %s' % (pr_slug, is_pr), file=sys.stderr)
-
     if repo_owner == 'dubious-developments':
         if not is_pr:
             deploy_dir = 'release-candidate'
@@ -63,10 +61,10 @@ def main(argv):
         build_version
     ]
 
-    if is_dry_run:
-        print(' '.join('"%s"' % arg if ' ' in arg else arg for arg in command))
+    print('Running command: ' + ' '.join('"%s"' % arg if ' ' in arg else arg for arg in command), file=sys.stderr)
 
-    subprocess.call(command)
+    if not is_dry_run:
+        subprocess.call(command)
     return 0
 
 if __name__ == '__main__':

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -18,6 +18,8 @@ export VERSION=$4
 
 pushd "$CURRENT_DIR/.."
 
+export SHA=$(git rev-parse --verify HEAD)
+
 # Clone the GitHub pages repository.
 git clone https://github.com/dubious-developments/dubious-developments.github.io
 

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -23,7 +23,7 @@ git clone https://github.com/dubious-developments/dubious-developments.github.io
 
 # Try to push until we succeed.
 i=0
-while [ i < 5 ] && ! ./ci/try-deploy-to-gh-pages.sh; do
+while (( i < 5 )) && ! ./ci/try-deploy-to-gh-pages.sh; do
     # Sleep for a while.
     sleep 10
     # Try again.

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -25,7 +25,7 @@ git clone https://github.com/dubious-developments/dubious-developments.github.io
 rm -rf "dubious-developments.github.io/$TARGET_DIRECTORY"
 
 # Copy the build and the coverage to the GitHub pages directory.
-mkdir "dubious-developments.github.io/$TARGET_DIRECTORY"
+mkdir -p "dubious-developments.github.io/$TARGET_DIRECTORY"
 cp -r build/* "dubious-developments.github.io/$TARGET_DIRECTORY"
 mkdir "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"
 cp -r coverage/Firefox*/* "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -5,55 +5,33 @@
 set -e
 
 CURRENT_DIR=$(dirname $0)
-ACCESS_TOKEN=$1
+export ACCESS_TOKEN=$1
 
 # The second parameter is the directory to store the build in.
-TARGET_DIRECTORY=$2
+export TARGET_DIRECTORY=$2
 
 # The third parameter is the (human-readable) name of the build.
-NAME=$3
+export NAME=$3
 
 # The fourth parameter is the build's version.
-VERSION=$4
+export VERSION=$4
 
 pushd "$CURRENT_DIR/.."
 
 # Clone the GitHub pages repository.
 git clone https://github.com/dubious-developments/dubious-developments.github.io
 
-# Delete the old build, if any.
-rm -rf "dubious-developments.github.io/$TARGET_DIRECTORY"
-
-# Copy the build and the coverage to the GitHub pages directory.
-mkdir -p "dubious-developments.github.io/$TARGET_DIRECTORY"
-cp -r build/* "dubious-developments.github.io/$TARGET_DIRECTORY"
-mkdir "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"
-cp -r coverage/Firefox*/* "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"
-
-# Create build name and version files.
-echo "$NAME" > "dubious-developments.github.io/$TARGET_DIRECTORY/build-name"
-echo "$VERSION" > "dubious-developments.github.io/$TARGET_DIRECTORY/version"
-
-pushd dubious-developments.github.io
-
-# Regenerate the index.
-python3 ../ci/generate-index.py > index.html
-
-# Add the changes.
-git add .
-
-# Create a commit.
-git -c user.name='Dubious Spongebot' \
-    -c user.email='jonathan.vdc+dubious-spongebot@outlook.com' \
-    commit -m "Deploy $TARGET_DIRECTORY"
-
-# Push the changes.
-git push https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments/dubious-developments.github.io master &2> /dev/null
+# Try to push until we succeed.
+i=0
+while [ i < 5 ] && ! ./ci/try-deploy-to-gh-pages.sh; do
+    # Sleep for a while.
+    sleep 10
+    # Try again.
+    i=$((i+1))
+done
 
 # Add a comment to the pull request if this is the first time
 # we're deploying it to GitHub pages.
-python3 ../ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY"
-
-popd
+python3 ./ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY"
 
 popd

--- a/ci/generate-index.py
+++ b/ci/generate-index.py
@@ -9,14 +9,24 @@ def index_directories():
        each as an UnSHACLed build by looking for 'index.html' and
        'build-name' files. Returns a list of (name, directory) tuples."""
     unshacled_dirs = []
-    for top_level_dir in os.listdir():
+
+    # Search both the top-level directories and their subdirectories.
+    top_level_dirs = os.listdir()
+    search_dirs = [(directory, None) for directory in top_level_dirs] + [
+        (directory + '/' + nested_dir, directory)
+            for directory in top_level_dirs
+                if os.path.isdir(directory)
+                for nested_dir in os.listdir(directory)]
+
+    for (directory, tag) in search_dirs:
         try:
-            build_name = open(top_level_dir + '/build-name', mode='r')
+            build_name = open(directory + '/build-name', mode='r')
         except OSError:
             continue
 
-        if os.path.exists(top_level_dir + '/index.html'):
-            unshacled_dirs.append((build_name.readline().strip(), top_level_dir))
+        if os.path.exists(directory + '/index.html'):
+            prefix = '' if tag is None else '%s: ' % tag
+            unshacled_dirs.append((prefix + build_name.readline().strip(), directory))
 
     unshacled_dirs.sort(key=lambda tuple: tuple[0])
     return unshacled_dirs

--- a/ci/spongebot.py
+++ b/ci/spongebot.py
@@ -33,6 +33,19 @@ SALUTATIONS = [
     """Ha ha ha. What a story, {0}."""
 ]
 
+# Things Spongebot may post to indicate excitement.
+EXCITED_EMOJIS = [
+    '🎉',
+    '🎆',
+    '🎊',
+    '🥂',
+    '🦄',
+    '✨',
+    '🔥',
+    '😎',
+    '👌'
+]
+
 # Things Spongebot Squarepants may say to bid you farewell.
 VALEDICTIONS = [
     """Thanks for contributing! Keep up the good work and have a wonderful day!""",
@@ -40,6 +53,14 @@ VALEDICTIONS = [
     """This is a beautiful pull request! You included all the code. Good thinking!""",
     """You think about everything. Ha ha ha."""
 ]
+
+def generate_excitement():
+    """Randomly generates three emojis to express excitement."""
+    outer_index = random.randint(0, len(EXCITED_EMOJIS) - 1)
+    inner_index = random.randint(0, len(EXCITED_EMOJIS) - 2)
+    if inner_index >= outer_index:
+        inner_index += 1
+    return '{0}{1}{0}'.format(EXCITED_EMOJIS[outer_index], EXCITED_EMOJIS[inner_index])
 
 def generate_pull_request_deployed_comment(pull_request, deploy_directory_name):
     """Generates the body of the comment that is posted when a pull request
@@ -49,7 +70,7 @@ def generate_pull_request_deployed_comment(pull_request, deploy_directory_name):
 
     message_format = """{0}
 
-I built and deployed your pull request. 🎉🎆🎉
+I built and deployed your pull request. {3}
 You can try it out [here](https://dubious-developments.github.io/{1}/index.html).
 If you're looking for the coverage report, that's [right here](https://dubious-developments.github.io/{1}/coverage/index.html).
 
@@ -57,7 +78,7 @@ If you're looking for the coverage report, that's [right here](https://dubious-d
 
 > **Note:** it may take a little while before GitHub pages gets updated. Try again in a minute if your deployed build doesn't show up right away."""
 
-    return message_format.format(salutation, deploy_directory_name, valediction)
+    return message_format.format(salutation, deploy_directory_name, valediction, generate_excitement())
 
 def create_pull_request_deployed_comment(pull_request, deploy_directory_name):
     """Adds an issue comment to a pull request that links to the deployed build."""

--- a/ci/spongebot.py
+++ b/ci/spongebot.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# This script defines useful functionality for Spongebot.
+
+from __future__ import print_function
+import random
+
+def parse_deploy_directory_name(deploy_directory_name):
+    """Parses the name of a deploy directory as a pull request number.
+       Returns None if the deploy directory name does not identify
+       a pull request."""
+    prefix = 'pull-request-'
+    if deploy_directory_name.startswith(prefix):
+        try:
+            return int(deploy_directory_name[len(prefix):])
+        except ValueError:
+            return None
+    else:
+        return None
+
+def has_commented_on_pull_request(pull_request):
+    """Tells if Dubious Spongebot has commented on a pull request."""
+    for comment in pull_request.get_issue_comments():
+        if comment.user.login == 'dubious-spongebot':
+            return True
+    return False
+
+# Spongebot Squarepants' greetings.
+SALUTATIONS = [
+    """Oh hi there {0}!""",
+    """I did not hit her, it's not true! It's bullshit! I did not hit her! *I did naaaahht.* Oh hi {0}.""",
+    """Oh hi {0}. I didn't know it was you.""",
+    """Ha ha ha. What a story, {0}."""
+]
+
+# Things Spongebot Squarepants may say to bid you farewell.
+VALEDICTIONS = [
+    """Thanks for contributing! Keep up the good work and have a wonderful day!""",
+    """You're my favorite customer. Buh-bye.""",
+    """This is a beautiful pull request! You included all the code. Good thinking!""",
+    """You think about everything. Ha ha ha."""
+]
+
+def generate_pull_request_deployed_comment(pull_request, deploy_directory_name):
+    """Generates the body of the comment that is posted when a pull request
+       has been deployed to GitHub pages."""
+    salutation = random.choice(SALUTATIONS).format('@' + pull_request.user.login)
+    valediction = random.choice(VALEDICTIONS)
+
+    message_format = """{0}
+
+I built and deployed your pull request. 🎉🎆🎉
+You can try it out [here](https://dubious-developments.github.io/{1}/index.html).
+If you're looking for the coverage report, that's [right here](https://dubious-developments.github.io/{1}/coverage/index.html).
+
+{2}
+
+> **Note:** it may take a little while before GitHub pages gets updated. Try again in a minute if your deployed build doesn't show up right away."""
+
+    return message_format.format(salutation, deploy_directory_name, valediction)
+
+def create_pull_request_deployed_comment(pull_request, deploy_directory_name):
+    """Adds an issue comment to a pull request that links to the deployed build."""
+    pull_request.create_issue_comment(
+        generate_pull_request_deployed_comment(
+            pull_request,
+            deploy_directory_name))

--- a/ci/spongebot.py
+++ b/ci/spongebot.py
@@ -10,6 +10,7 @@ def parse_deploy_directory_name(deploy_directory_name):
        Returns None if the deploy directory name does not identify
        a pull request."""
     prefix = 'pull-request-'
+    deploy_directory_name = deploy_directory_name.split('/')[-1]
     if deploy_directory_name.startswith(prefix):
         try:
             return int(deploy_directory_name[len(prefix):])

--- a/ci/try-deploy-to-gh-pages.sh
+++ b/ci/try-deploy-to-gh-pages.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -e # Exit with nonzero exit code if anything fails
+
+# This file is based on the tutorial here: https://gist.github.com/domenic/ec8b0fc8ab45f39403dd
+
+# Delete the old build, if any.
+rm -rf "dubious-developments.github.io/$TARGET_DIRECTORY"
+
+# Copy the build and the coverage to the GitHub pages directory.
+mkdir -p "dubious-developments.github.io/$TARGET_DIRECTORY"
+cp -r build/* "dubious-developments.github.io/$TARGET_DIRECTORY"
+mkdir "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"
+cp -r coverage/Firefox*/* "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"
+
+# Create build name and version files.
+echo "$NAME" > "dubious-developments.github.io/$TARGET_DIRECTORY/build-name"
+echo "$VERSION" > "dubious-developments.github.io/$TARGET_DIRECTORY/version"
+
+pushd dubious-developments.github.io
+
+# Regenerate the index.
+python3 ../ci/generate-index.py > index.html
+
+# If there are no changes to the deployed build then just bail.
+if git diff --cached --exit-code; then
+    echo "No changes to the output on this push; exiting."
+    exit 0
+fi
+
+REPO_URL="https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments/dubious-developments.github.io"
+
+# Commit the "changes", i.e., the new version.
+# The delta will show diffs between new and old versions.
+echo "Committing changes..."
+git -c user.name='Dubious Spongebot' \
+    -c user.email='jonathan.vdc+dubious-spongebot@outlook.com' \
+    commit -m "Deploy $TARGET_DIRECTORY (${SHA})"
+
+# Now that we're all set up, we can push.
+echo "Pushing commit..."
+if git push $REPO_URL master &2> /dev/null; then
+    echo "Pushed commit"
+    popd
+else
+    # Nuke the commit we just made.
+    echo "Push failed. Nuking commit..."
+    git reset --hard HEAD^
+    # Do a git pull.
+    git pull $REPO_URL master
+    popd
+    exit 1
+fi

--- a/ci/try-deploy-to-gh-pages.sh
+++ b/ci/try-deploy-to-gh-pages.sh
@@ -25,12 +25,6 @@ pushd dubious-developments.github.io
 python3 ../ci/generate-index.py > index.html
 echo "Generated index."
 
-# If there are no changes to the deployed build then just bail.
-if git diff --cached --exit-code; then
-    echo "No changes to the output on this push; exiting."
-    exit 0
-fi
-
 REPO_URL="https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments/dubious-developments.github.io"
 
 # Commit the "changes", i.e., the new version.

--- a/ci/try-deploy-to-gh-pages.sh
+++ b/ci/try-deploy-to-gh-pages.sh
@@ -25,6 +25,12 @@ pushd dubious-developments.github.io
 python3 ../ci/generate-index.py > index.html
 echo "Generated index."
 
+# If there are no changes to the deployed build then just bail.
+if git diff --cached --exit-code; then
+    echo "No changes to the output on this push; exiting."
+    exit 0
+fi
+
 REPO_URL="https://dubious-spongebot:$ACCESS_TOKEN@github.com/dubious-developments/dubious-developments.github.io"
 
 # Commit the "changes", i.e., the new version.

--- a/ci/try-deploy-to-gh-pages.sh
+++ b/ci/try-deploy-to-gh-pages.sh
@@ -25,6 +25,9 @@ pushd dubious-developments.github.io
 python3 ../ci/generate-index.py > index.html
 echo "Generated index."
 
+# Add files.
+git add .
+
 # If there are no changes to the deployed build then just bail.
 if git diff --cached --exit-code; then
     echo "No changes to the output on this push; exiting."

--- a/ci/try-deploy-to-gh-pages.sh
+++ b/ci/try-deploy-to-gh-pages.sh
@@ -6,12 +6,14 @@ set -e # Exit with nonzero exit code if anything fails
 
 # Delete the old build, if any.
 rm -rf "dubious-developments.github.io/$TARGET_DIRECTORY"
+echo "Deleted old $TARGET_DIRECTORY directory."
 
 # Copy the build and the coverage to the GitHub pages directory.
 mkdir -p "dubious-developments.github.io/$TARGET_DIRECTORY"
 cp -r build/* "dubious-developments.github.io/$TARGET_DIRECTORY"
 mkdir "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"
 cp -r coverage/Firefox*/* "dubious-developments.github.io/$TARGET_DIRECTORY/coverage"
+echo "Created new $TARGET_DIRECTORY directory."
 
 # Create build name and version files.
 echo "$NAME" > "dubious-developments.github.io/$TARGET_DIRECTORY/build-name"
@@ -21,6 +23,7 @@ pushd dubious-developments.github.io
 
 # Regenerate the index.
 python3 ../ci/generate-index.py > index.html
+echo "Generated index."
 
 # If there are no changes to the deployed build then just bail.
 if git diff --cached --exit-code; then

--- a/ci/try-deploy-to-gh-pages.sh
+++ b/ci/try-deploy-to-gh-pages.sh
@@ -29,7 +29,7 @@ echo "Generated index."
 git add .
 
 # If there are no changes to the deployed build then just bail.
-if git diff --cached --exit-code; then
+if git diff -s --cached --exit-code; then
     echo "No changes to the output on this push; exiting."
     exit 0
 fi


### PR DESCRIPTION
The changed proposed in this PR will enable Spongebot to maintain any fork of UnSHACLed, provided that Travis CI has been enabled for that fork.

To enable Travis CI, sign in using you GitHub account at https://travis-ci.org/ and add your fork of UnSHACLed to the list of projects for which CI is enabled. All of this shouldn't take more than five minutes.