### PR TITLE
Define convenient task-execution methods in TaskProcessor

### DIFF
--- a/src/entities/taskProcessor.ts
+++ b/src/entities/taskProcessor.ts
@@ -60,6 +60,30 @@ export class TaskProcessor<TData, TTaskMetadata> {
     }
 
     /**
+     * Deschedules and executes tasks until the task schedule
+     * becomes empty..
+     */
+    public processAllTasks(): void {
+        while (!this.isScheduleEmpty) {
+            this.processTask();
+        }
+    }
+
+    /**
+     * Deschedules and executes tasks until a particular time in
+     * milliseconds has passed or the task schedule becomes empty.
+     * @param milliseconds The duration in milliseconds during which tasks may be executed.
+     */
+    public processTasksDuring(milliseconds: number): void {
+        let start = Date.now();
+        let current = start;
+        while (!this.isScheduleEmpty && current - start < milliseconds) {
+            this.processTask();
+            current = Date.now();
+        }
+    }
+
+    /**
      * Tells if the model's task schedule is empty.
     */
     public get isScheduleEmpty(): boolean {

--- a/test/taskProcessor.test.ts
+++ b/test/taskProcessor.test.ts
@@ -23,7 +23,23 @@ describe("TaskProcessor Class", () => {
             (box) => box.num++, 0);
         processor.schedule(task);
         expect(processor.isScheduleEmpty).toEqual(false);
-        processor.processTask();
+        processor.processAllTasks();
         expect(numBox.num).toEqual(1);
+    });
+
+    it("should not run forever unless we want it to", () => {
+        let processor = new TaskProcessor.TaskProcessor<void, void>(
+            undefined,
+            new TaskProcessor.FifoTaskQueue<void, void>());
+        let taskCount = 0;
+        let createTask = (createNext) => new TaskProcessor.ProcessorTask<void, void>(
+            (nothing) => { taskCount += 1; processor.schedule(createNext(createNext)); }, undefined);
+        processor.schedule(createTask(createTask));
+
+        let before = Date.now();
+        processor.processTasksDuring(500);
+        let after = Date.now();
+        expect(after - before).toBeLessThanOrEqual(1000);
+        expect(taskCount).toBeGreaterThan(1);
     });
 });


### PR DESCRIPTION
This pull request suggests defining two new methods in `TaskProcessor`: `processAllTasks` and `processTasksDuring`. The former processes tasks until the task schedule becomes empty, the latter processes tasks until either the task schedule becomes empty or a particular number of milliseconds elapse. These should make managing the task schedule based on timing measurements a little easier.