### PR TITLE
Senile spongebot fix

### DIFF
--- a/ci/comment-pr-deployed.py
+++ b/ci/comment-pr-deployed.py
@@ -20,11 +20,11 @@ def comment_pull_request_deployed(argv):
         argv = [argv[0]] + argv[2:]
         is_dry_run = True
 
-    if len(argv) != 3:
-        print('Usage: comment-pr-deployed [-d] access-token deploy-directory', file=sys.stderr)
+    if len(argv) != 4:
+        print('Usage: comment-pr-deployed [-d] access-token deploy-directory repo-slug', file=sys.stderr)
         return 1
 
-    _, access_token, deploy_directory = argv
+    _, access_token, deploy_directory, repo_slug = argv
 
     pr_number = parse_deploy_directory_name(deploy_directory)
     if pr_number is None:
@@ -33,7 +33,7 @@ def comment_pull_request_deployed(argv):
 
     # Authenticate and grab the repo.
     gh = Github(access_token)
-    repo = gh.get_repo('dubious-developments/UnSHACLed')
+    repo = gh.get_repo(repo_slug)
     pr = repo.get_pull(pr_number)
 
     # Make sure that we haven't commented already.

--- a/ci/deploy-to-gh-pages.py
+++ b/ci/deploy-to-gh-pages.py
@@ -59,7 +59,8 @@ def main(argv):
         token,
         deploy_dir,
         build_name,
-        build_version
+        build_version,
+        repo_slug
     ]
 
     if is_dry_run:

--- a/ci/deploy-to-gh-pages.sh
+++ b/ci/deploy-to-gh-pages.sh
@@ -16,6 +16,10 @@ export NAME=$3
 # The fourth parameter is the build's version.
 export VERSION=$4
 
+# The fifth parameter is the slug of the repository we are
+# deploying from.
+export REPO_SLUG=$5
+
 pushd "$CURRENT_DIR/.."
 
 export SHA=$(git rev-parse --verify HEAD)
@@ -31,9 +35,5 @@ while (( i < 5 )) && ! ./ci/try-deploy-to-gh-pages.sh; do
     # Try again.
     i=$((i+1))
 done
-
-# Add a comment to the pull request if this is the first time
-# we're deploying it to GitHub pages.
-python3 ./ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY"
 
 popd

--- a/ci/try-deploy-to-gh-pages.sh
+++ b/ci/try-deploy-to-gh-pages.sh
@@ -47,6 +47,11 @@ git -c user.name='Dubious Spongebot' \
 echo "Pushing commit..."
 if git push $REPO_URL master &2> /dev/null; then
     echo "Pushed commit"
+
+    # Add a comment to the pull request if this is the first time
+    # we're deploying it to GitHub pages.
+    python3 ./ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY" "$REPO_SLUG"
+
     popd
 else
     # Nuke the commit we just made.

--- a/ci/try-deploy-to-gh-pages.sh
+++ b/ci/try-deploy-to-gh-pages.sh
@@ -47,12 +47,11 @@ git -c user.name='Dubious Spongebot' \
 echo "Pushing commit..."
 if git push $REPO_URL master &2> /dev/null; then
     echo "Pushed commit"
+    popd
 
     # Add a comment to the pull request if this is the first time
     # we're deploying it to GitHub pages.
     python3 ./ci/comment-pr-deployed.py "$ACCESS_TOKEN" "$TARGET_DIRECTORY" "$REPO_SLUG"
-
-    popd
 else
     # Nuke the commit we just made.
     echo "Push failed. Nuking commit..."


### PR DESCRIPTION
After some tinkering, I managed to fix a bug where Spongebot would comment on pull requests from the main repository (e.g., #11, which IIUC predates Spongebot) instead of the pull request with the same issue number in a fork.

The fix turned out to be fairly straightforward. Let's get this merged in quickly so we can update our forks ASAP.