### PR TITLE
prefixes and center bug

### DIFF
--- a/src/components/MxGraph.tsx
+++ b/src/components/MxGraph.tsx
@@ -9,6 +9,7 @@ import {List} from 'semantic-ui-react';
 import {Button} from 'semantic-ui-react';
 import {MxGraphProps} from "./interfaces/interfaces";
 import {ModelObserver} from "../entities/model";
+import {PrefixMap} from "../persistence/graph";
 
 declare let mxClient, mxUtils, mxGraph, mxDragSource, mxEvent, mxCell, mxGeometry, mxRubberband, mxEditor,
     mxRectangle, mxPoint, mxConstants, mxPerimeter, mxEdgeStyle, mxStackLayout: any;
@@ -414,14 +415,14 @@ class MxGraph extends React.Component<MxGraphProps, any> {
         this.nameToStandardCellDict.setValue('row', row);
     }
 
-    parseDataGraphToBlocks(store: any) {
+    parseDataGraphToBlocks(store: any, prefixes: PrefixMap) {
         // let DASH = $rdf.Namespace("http://datashapes.org/dash#");
         let RDF = $rdf.Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#");
         // let RDFS = $rdf.Namespace("http://www.w3.org/2000/01/rdf-schema#");
         // let SCHEMA = $rdf.Namespace("http://schema.org/");
         let SH = $rdf.Namespace("http://www.w3.org/ns/shacl#");
         // let XSD = $rdf.Namespace("http://www.w3.org/2001/XMLSchema#");
-
+        // console.log(prefixes);
         let triples = store.statements;
         let newTriples = new Collections.Set<Triple>();
 
@@ -461,10 +462,10 @@ class MxGraph extends React.Component<MxGraphProps, any> {
         this.blockToCellDict.clear();
     }
 
-    visualizeDataGraph(store: any) {
+    visualizeDataGraph(store: any, prefixes: PrefixMap) {
         this.clear();
         let {graph} = this.state;
-        let blocks = this.parseDataGraphToBlocks(store);
+        let blocks = this.parseDataGraphToBlocks(store, prefixes);
         let model = graph.getModel();
         let parent = graph.getDefaultParent();
 

--- a/src/components/MxGraph.tsx
+++ b/src/components/MxGraph.tsx
@@ -17,6 +17,8 @@ let $rdf = require('rdflib');
 
 class MxGraph extends React.Component<MxGraphProps, any> {
 
+    private editor: any;
+
     private nameToStandardCellDict: Collections.Dictionary<string, any>;
     private blockToCellDict: Collections.Dictionary<Block, any>;
     private subjectToBlockDict: Collections.Dictionary<string, Block>;
@@ -45,6 +47,7 @@ class MxGraph extends React.Component<MxGraphProps, any> {
         this.visualizeDataGraph = this.visualizeDataGraph.bind(this);
         this.handleUserAction = this.handleUserAction.bind(this);
         this.addTemplate = this.addTemplate.bind(this);
+        this.fitGraph = this.fitGraph.bind(this);
       
         this.nameToStandardCellDict = new Collections.Dictionary<string, any>();
         this.blockToCellDict = new Collections.Dictionary<Block, any>((b) => b.name);
@@ -718,6 +721,10 @@ class MxGraph extends React.Component<MxGraphProps, any> {
 
     }
 
+    public fitGraph() {
+        this.editor.execute("fit");
+    }
+
     main(container: HTMLElement | null): void {
         // Checks if the browser is supported
         if (!container) {
@@ -751,6 +758,7 @@ class MxGraph extends React.Component<MxGraphProps, any> {
             model.tasks.processAllTasks();
 
             let editor = new mxEditor();
+            this.editor = editor;
 
             // Creates the graph inside the given container
             editor.setGraphContainer(container);

--- a/src/components/MxGraph.tsx
+++ b/src/components/MxGraph.tsx
@@ -484,7 +484,9 @@ class MxGraph extends React.Component<MxGraphProps, any> {
                 let longestname = 0;
                 b.traits.forEach(trait => {
                     let temprow = model.cloneCell(this.nameToStandardCellDict.getValue('row'));
-                    let name = this.replacePrefixes(trait.predicate, prefixes) + " :  " + this.replacePrefixes(trait.object, prefixes);
+                    let name = this.replacePrefixes(trait.predicate, prefixes)
+                        + " :  "
+                        + this.replacePrefixes(trait.object, prefixes);
                     // let name = trait.predicate + " :  " + trait.object;
                     longestname = Math.max(name.length, longestname);
                     temprow.value = {name: name, trait: trait};

--- a/src/components/MxGraph.tsx
+++ b/src/components/MxGraph.tsx
@@ -423,7 +423,7 @@ class MxGraph extends React.Component<MxGraphProps, any> {
         // let SCHEMA = $rdf.Namespace("http://schema.org/");
         let SH = $rdf.Namespace("http://www.w3.org/ns/shacl#");
         // let XSD = $rdf.Namespace("http://www.w3.org/2001/XMLSchema#");
-        // console.log(prefixes);
+
         let triples = store.statements;
         let newTriples = new Collections.Set<Triple>();
 
@@ -523,7 +523,7 @@ class MxGraph extends React.Component<MxGraphProps, any> {
      * @param {string} s
      * @param {PrefixMap} prefixes
      */
-    replacePrefixes(s: string, prefixes: PrefixMap) {
+    replacePrefixes(s: string, prefixes: PrefixMap): string {
         Object.keys(prefixes).forEach(key => {
             s = s.replace(prefixes[key], key + ":");
         });

--- a/src/components/MxGraph.tsx
+++ b/src/components/MxGraph.tsx
@@ -10,6 +10,7 @@ import {Button} from 'semantic-ui-react';
 import {MxGraphProps} from "./interfaces/interfaces";
 import {ModelObserver} from "../entities/model";
 import {PrefixMap} from "../persistence/graph";
+import SideBar from "./Sidebar";
 
 declare let mxClient, mxUtils, mxGraph, mxDragSource, mxEvent, mxCell, mxGeometry, mxRubberband, mxEditor,
     mxRectangle, mxPoint, mxConstants, mxPerimeter, mxEdgeStyle, mxStackLayout: any;
@@ -440,6 +441,7 @@ class MxGraph extends React.Component<MxGraphProps, any> {
             let subject = triple.subject;
             let predicate = triple.predicate;
             let object = triple.object;
+
             let subjectBlock = this.subjectToBlockDict.getValue(subject);
             if (subjectBlock) {
                 if (predicate === RDF("type").uri && object === SH("NodeShape").uri) {
@@ -471,7 +473,7 @@ class MxGraph extends React.Component<MxGraphProps, any> {
 
         blocks.forEach(b => {
             let v1 = model.cloneCell(this.nameToStandardCellDict.getValue('block'));
-            v1.value = b;
+            v1.value = this.replacePrefixes(b.name, prefixes);
             this.blockToCellDict.setValue(b, v1);
         });
 
@@ -482,7 +484,8 @@ class MxGraph extends React.Component<MxGraphProps, any> {
                 let longestname = 0;
                 b.traits.forEach(trait => {
                     let temprow = model.cloneCell(this.nameToStandardCellDict.getValue('row'));
-                    let name = trait.predicate + ": " + trait.object;
+                    let name = this.replacePrefixes(trait.predicate, prefixes) + " :  " + this.replacePrefixes(trait.object, prefixes);
+                    // let name = trait.predicate + " :  " + trait.object;
                     longestname = Math.max(name.length, longestname);
                     temprow.value = {name: name, trait: trait};
                     v1.insert(temprow);
@@ -511,6 +514,18 @@ class MxGraph extends React.Component<MxGraphProps, any> {
 
         let layout = new mxStackLayout(graph, false, 35);
         layout.execute(graph.getDefaultParent());
+    }
+
+    /**
+     * Replaces prefixes where possible in the string s
+     * @param {string} s
+     * @param {PrefixMap} prefixes
+     */
+    replacePrefixes(s: string, prefixes: PrefixMap) {
+        Object.keys(prefixes).forEach(key => {
+            s = s.replace(prefixes[key], key + ":");
+        });
+        return s;
     }
 
     configureStylesheet(graph: any) {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -122,7 +122,7 @@ class SideBar extends React.Component<SidebarProps, any> {
         let items = Array<JSX.Element>();
 
         Object.keys(SideBar.prefixes).forEach(key => {
-            let line = key + ": " + SideBar.prefixes[key]
+            let line = key + ": " + SideBar.prefixes[key];
             items.push(
                 <Menu.Item
                     as="a"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,7 +15,7 @@ class SideBar extends React.Component<SidebarProps, any> {
     static GeneralMenuItems = ["Arrow", "Rectangle"];
     static TemplateMenuItems = ["Address", "Person"];
 
-    static prefixes : PrefixMap;
+    static prefixes: PrefixMap;
 
     constructor(props: any) {
         super(props);
@@ -31,7 +31,7 @@ class SideBar extends React.Component<SidebarProps, any> {
         this.getMenuItemsFiltered = this.getMenuItemsFiltered.bind(this);
         this.DynamicMenu = this.DynamicMenu.bind(this);
         this.addTemplateEntry = this.addTemplateEntry.bind(this);
-        this.PrefixMenu= this.PrefixMenu.bind(this);
+        this.PrefixMenu = this.PrefixMenu.bind(this);
     }
 
     static setPrefixes(prefixes: PrefixMap) {
@@ -239,13 +239,13 @@ class SideBar extends React.Component<SidebarProps, any> {
                     </div>
                 )
                 }
-                {this.state.content === 2 &&(
+                {this.state.content === 2 && (
                     <Menu.Item>
                         <this.PrefixMenu />
                     </Menu.Item>
                 )
                 }
-                {this.state.content === 3 &&(
+                {this.state.content === 3 && (
                     <Menu.Item>
                         <TreeView/>
                     </Menu.Item>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {Sidebar, Menu, Image, Input, Dropdown, List, Button, Label, Popup} from 'semantic-ui-react';
 import TreeView from './treeView';
 import {SidebarProps} from './interfaces/interfaces';
+import {PrefixMap} from "../persistence/graph";
 
 class SideBar extends React.Component<SidebarProps, any> {
 
@@ -13,6 +14,8 @@ class SideBar extends React.Component<SidebarProps, any> {
     static SHACLMenuItems = ["Shape", "Node Shape", "Property Shape"];
     static GeneralMenuItems = ["Arrow", "Rectangle"];
     static TemplateMenuItems = ["Address", "Person"];
+
+    static prefixes : PrefixMap;
 
     constructor(props: any) {
         super(props);
@@ -28,6 +31,11 @@ class SideBar extends React.Component<SidebarProps, any> {
         this.getMenuItemsFiltered = this.getMenuItemsFiltered.bind(this);
         this.DynamicMenu = this.DynamicMenu.bind(this);
         this.addTemplateEntry = this.addTemplateEntry.bind(this);
+        this.PrefixMenu= this.PrefixMenu.bind(this);
+    }
+
+    static setPrefixes(prefixes: PrefixMap) {
+        SideBar.prefixes = prefixes;
     }
 
     getMenuItemsFiltered(kind: string, query: string) {
@@ -108,6 +116,28 @@ class SideBar extends React.Component<SidebarProps, any> {
                 />
             )
         });
+    }
+
+    PrefixMenu(props: any) {
+        let items = Array<JSX.Element>();
+
+        Object.keys(SideBar.prefixes).forEach(key => {
+            let line = key + ": " + SideBar.prefixes[key]
+            items.push(
+                <Menu.Item
+                    as="a"
+                    id={SideBar.prefixes[key]}
+                    content={line}
+                    key={key}
+                />
+            );
+        });
+
+        return (
+            <Menu.Menu>
+                {items}
+            </Menu.Menu>
+        );
     }
 
     render() {
@@ -210,7 +240,9 @@ class SideBar extends React.Component<SidebarProps, any> {
                 )
                 }
                 {this.state.content === 2 &&(
-                    <label>Edit Prefixes</label>
+                    <Menu.Item>
+                        <this.PrefixMenu />
+                    </Menu.Item>
                 )
                 }
                 {this.state.content === 3 &&(

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,7 +7,8 @@ class SideBar extends React.Component<SidebarProps, any> {
 
     static sidebarOptions = [
         {key: 1, text: 'Add Components', value: 1},
-        {key: 2, text: 'Project structure', value: 2}
+        {key: 2, text: 'Prefixes', value: 2},
+        {key: 3, text: 'Project structure', value: 3}
     ];
     static SHACLMenuItems = ["Shape", "Node Shape", "Property Shape"];
     static GeneralMenuItems = ["Arrow", "Rectangle"];
@@ -141,7 +142,7 @@ class SideBar extends React.Component<SidebarProps, any> {
                         pointing="top right"
                     />
                 </Menu.Item>
-                {this.state.content === defaultOption ? (
+                {this.state.content === defaultOption && (
                     <div>
                         <Menu.Item>
                             <Input
@@ -206,7 +207,13 @@ class SideBar extends React.Component<SidebarProps, any> {
                             inverted={true}
                         />
                     </div>
-                ) : (
+                )
+                }
+                {this.state.content === 2 &&(
+                    <label>Edit Prefixes</label>
+                )
+                }
+                {this.state.content === 3 &&(
                     <Menu.Item>
                         <TreeView/>
                     </Menu.Item>

--- a/src/persistence/graph.ts
+++ b/src/persistence/graph.ts
@@ -5,7 +5,7 @@ import { TimeCapsule } from "../entities/timeCapsule";
 
 type Triple = { subject: string, predicate: string, object: string };
 
-type PrefixMap = { [prefix: string]: string };
+export type PrefixMap = { [prefix: string]: string };
 
 /**
  * A mutable wrapper for library-specific triple stores.

--- a/src/services/ModelTasks.ts
+++ b/src/services/ModelTasks.ts
@@ -125,6 +125,10 @@ export class VisualizeComponent extends Task<ModelData, ModelTaskMetadata> {
                     let graph = component.getPart(part);
                     graph.query(
                         store => this.mxGraph.visualizeDataGraph(store));
+
+                    // fit the graph again
+                    this.mxGraph.fitGraph();
+
                 } else {
                     console.log("error: could not find MxGraph");
                 }
@@ -141,7 +145,7 @@ export class VisualizeComponent extends Task<ModelData, ModelTaskMetadata> {
 }
 
 /*
- * Load the validationReport from the Model
+ * Load the validationReport from the Model and show it in mxGraph
  */
 export class GetValidationReport extends Task<ModelData, ModelTaskMetadata> {
 
@@ -158,7 +162,9 @@ export class GetValidationReport extends Task<ModelData, ModelTaskMetadata> {
         let component: any = data.getComponent(ModelComponent.ValidationReport);
         if (component) {
             let report = component.getRoot();
-            this.mxGraph.handleConformance(report);
+            if (this.mxGraph) {
+                this.mxGraph.handleConformance(report);
+            }
         } else {
             console.log("Could not find the ModelComponent: ", ModelComponent.ValidationReport);
         }

--- a/src/services/ModelTasks.ts
+++ b/src/services/ModelTasks.ts
@@ -7,6 +7,7 @@ import {Task} from "../entities/task";
 import MxGraph from "../components/MxGraph";
 import { ImmutableGraph } from "../persistence/graph";
 import { Component } from "../persistence/component";
+import SideBar from "../components/Sidebar";
 
 /**
  * First search the component which belongs to the fileName
@@ -124,7 +125,9 @@ export class VisualizeComponent extends Task<ModelData, ModelTaskMetadata> {
                 if (this.mxGraph) {
                     let graph = component.getPart(part);
                     graph.query(
-                        store => this.mxGraph.visualizeDataGraph(store));
+                        store => this.mxGraph.visualizeDataGraph(store, graph.getPrefixes()));
+
+                    SideBar.setPrefixes(graph.getPrefixes());
 
                     // fit the graph again
                     this.mxGraph.fitGraph();


### PR DESCRIPTION
This pr fixes some of the feedback given by peer tests.


The graph view centers after importing a file.

There is now a prefix list in the sidebar (also some refactoring of the sidebar happened to make it easier to add new uses of the sidebar in the future).

While rendering the graph long URI's are now replaced by prefixes, which makes the graph view much clearer.