### PR TITLE
Run Selenium tests on Mac OS X CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
       sudo apt update;
       sudo apt install mono-devel mono-complete nuget;
     else
-      brew update && brew install mono;
+      brew update && brew install mono && brew install nuget;
     fi
   # Build sshpass 1.06 from source. We need it to deploy a nightly
   # build of UnSHACLed to the server.

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ install:
       echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list;
       sudo apt update;
       sudo apt install mono-devel mono-complete nuget;
+    else
+      brew update && brew install mono;
     fi
   # Build sshpass 1.06 from source. We need it to deploy a nightly
   # build of UnSHACLed to the server.
@@ -53,9 +55,7 @@ script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then XVFB_RUN=xvfb-run; fi
   - $XVFB_RUN gulp test
   # Run the Selenium tests.
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      pushd selenium && make nuget && make && $XVFB_RUN make TEST_OPTIONS="--no-build-app" run && popd;
-    fi
+  - pushd selenium && make nuget && make && $XVFB_RUN make TEST_OPTIONS="--no-build-app" run && popd
   # Run SonarCloud, but only on Linux.
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ ! -z "$SONARCLOUD_KEY" ]; then sonar-scanner; fi
   # Deploy a nightly build when all tests are successful for a master branch commit.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,4 +30,4 @@ test_script:
   # Run tests.
   - gulp test
   # Run Selenium tests. TODO: get URL to index.html right on Windows.
-  # - pushd selenium && run-ci.bat && popd
+  - pushd selenium && run-ci.bat && popd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,4 +30,4 @@ test_script:
   # Run tests.
   - gulp test
   # Run Selenium tests. TODO: get URL to index.html right on Windows.
-  - pushd selenium && run-ci.bat && popd
+  # - pushd selenium && run-ci.bat && popd

--- a/selenium/Makefile
+++ b/selenium/Makefile
@@ -1,7 +1,7 @@
 .PHONY: nuget clean all run
 
 all:
-	msbuild selenium.sln
+	xbuild selenium.sln
 
 run:
 	mono ./bin/Debug/selenium-tests.exe $(TEST_OPTIONS)

--- a/selenium/Program.cs
+++ b/selenium/Program.cs
@@ -157,15 +157,15 @@ namespace SeleniumTests
         /// <param name="names">The names to parse.</param>
         /// <param name="log">A log for sending errors to.</param>
         /// <returns>A list of web driver builders.</returns>
-        private static IEnumerable<Func<IWebDriver>> ParseBrowserNames(
+        private static IReadOnlyDictionary<string, Func<IWebDriver>> ParseBrowserNames(
             IEnumerable<string> names, ILog log)
         {
-            var browsersToUse = new List<Func<IWebDriver>>();
-            foreach (var name in names)
+            var browsersToUse = new Dictionary<string, Func<IWebDriver>>();
+            foreach (var name in names.Distinct())
             {
                 if (Drivers.ContainsKey(name))
                 {
-                    browsersToUse.Add(Drivers[name]);
+                    browsersToUse[name] = Drivers[name];
                 }
                 else
                 {
@@ -209,14 +209,18 @@ namespace SeleniumTests
         /// </summary>
         /// <param name="uri">The URI to test.</param>
         /// <param name="driverBuilders">
-        /// A sequence of functions that each produce a driver to run the tests with.
+        /// A mapping of driver names to functions that each produce
+        /// a driver to run the tests with.
         /// </param>
         /// <param name="log">A log to send messages to.</param>
-        private static void Run(string uri, IEnumerable<Func<IWebDriver>> driverBuilders, ILog log)
+        private static void Run(
+            string uri,
+            IReadOnlyDictionary<string, Func<IWebDriver>> driverBuilders,
+            ILog log)
         {
             foreach (var builder in driverBuilders)
             {
-                using (IWebDriver driver = builder())
+                using (IWebDriver driver = builder.Value())
                 {
                     foreach (var testCase in TestCases)
                     {
@@ -224,7 +228,7 @@ namespace SeleniumTests
                         driver.Navigate().GoToUrl(uri);
 
                         // Then run the actual test case.
-                        testCase.Run(driver, log);
+                        testCase.Run(driver, builder.Key, log);
                     }
                 }
             }

--- a/selenium/Program.cs
+++ b/selenium/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -94,8 +94,14 @@ namespace SeleniumTests
                 var absPath = Path.GetFullPath(Path.Combine("..", "build", "index.html")).TrimStart('/');
                 if (Path.DirectorySeparatorChar == '\\')
                 {
-                    // <Shivers>
+                    // Welcome to Windows file URL hell.
                     absPath = absPath.Replace(Path.DirectorySeparatorChar, '/');
+                    int colonIndex = absPath.IndexOf(":");
+                    if (colonIndex > 0)
+                    {
+                        // Make the drive letter lowercase.
+                        absPath = absPath.Substring(0, colonIndex).ToLower() + absPath.Substring(colonIndex);
+                    }
                 }
                 testUrl = "file:///" + absPath;
             }

--- a/selenium/TestCase.cs
+++ b/selenium/TestCase.cs
@@ -40,11 +40,12 @@ namespace SeleniumTests
         /// Runs this test case against a web driver.
         /// </summary>
         /// <param name="driver">A web driver to use.</param>
+        /// <param name="driverName">The name of the driver being used.</param>
         /// <param name="log">A log to send messages to.</param>
         /// <returns>
         /// <c>true</c> if the test was successful; otherwise, <c>false</c>.
         /// </returns>
-        public bool Run(IWebDriver driver, ILog log)
+        public bool Run(IWebDriver driver, string driverName, ILog log)
         {
             try
             {
@@ -57,11 +58,29 @@ namespace SeleniumTests
                     new Pixie.LogEntry(
                         Severity.Error,
                         new Diagnostic(
-                            new Quotation(Description, 2),
+                            driverName,
                             "error",
                             Colors.Red,
-                            "assertion failed",
+                            new Quotation(Description, 2),
                             ex.FormattedMessage)));
+                return false;
+            }
+            catch (Exception ex)
+            {
+                log.Log(
+                    new Pixie.LogEntry(
+                        Severity.Error,
+                        new Diagnostic(
+                            driverName,
+                            "error",
+                            Colors.Red,
+                            new Quotation(Description, 2),
+                            new Sequence(
+                                Quotation.QuoteEvenInBold(
+                                "unhandled exception of type ",
+                                ex.GetType().FullName,
+                                "."),
+                                new Paragraph(ex.ToString())))));
                 return false;
             }
         }


### PR DESCRIPTION
Selenium tests were previously run on Linux CI builds only. This PR extends them to also run on Mac OS X.