### PR TITLE
Make Selenium tests more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,13 @@ script:
   # Run the tests.
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then XVFB_RUN=xvfb-run; fi
   - $XVFB_RUN gulp test
-  # Run the Selenium tests.
-  - pushd selenium && make nuget && make && $XVFB_RUN make TEST_OPTIONS="--no-build-app --browsers firefox chrome" run && popd
+  # Run the Selenium tests. Go with Firefox and Chrome on Linux, add Safari on Mac OS X.
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      SELENIUM_BROWSERS="firefox chrome safari";
+    else
+      SELENIUM_BROWSERS="firefox chrome";
+    fi
+  - pushd selenium && make nuget && make && $XVFB_RUN make TEST_OPTIONS="--no-build-app --browsers $SELENIUM_BROWSERS" run && popd
   # Run SonarCloud, but only on Linux.
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ ! -z "$SONARCLOUD_KEY" ]; then sonar-scanner; fi
   # Deploy a nightly build when all tests are successful for a master branch commit.

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
   - $XVFB_RUN gulp test
   # Run the Selenium tests. Go with Firefox and Chrome on Linux, add Safari on Mac OS X.
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      sudo safaridriver --enable;
       SELENIUM_BROWSERS="firefox chrome safari";
     else
       SELENIUM_BROWSERS="firefox chrome";

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
     else
       SELENIUM_BROWSERS="firefox chrome";
     fi
-  - pushd selenium && make nuget && make && $XVFB_RUN make TEST_OPTIONS="--no-build-app --browsers $SELENIUM_BROWSERS" run && popd
+  - pushd selenium && make nuget && make && $XVFB_RUN make TEST_OPTIONS="--no-build-app --color --browsers $SELENIUM_BROWSERS" run && popd
   # Run SonarCloud, but only on Linux.
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ ! -z "$SONARCLOUD_KEY" ]; then sonar-scanner; fi
   # Deploy a nightly build when all tests are successful for a master branch commit.

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,13 +57,17 @@ script:
   # Run the tests.
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then XVFB_RUN=xvfb-run; fi
   - $XVFB_RUN gulp test
-  # Run the Selenium tests. Go with Firefox and Chrome on Linux, add Safari on Mac OS X.
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      sudo safaridriver --enable;
-      SELENIUM_BROWSERS="firefox chrome safari";
-    else
-      SELENIUM_BROWSERS="firefox chrome";
-    fi
+  # Run the Selenium tests. Go with Firefox and Chrome on both Linux and Mac OS X.
+  - SELENIUM_BROWSERS="firefox chrome"
+  # TODO: maybe try to add Safari on Mac OS X? Safari seems to run just fine,
+  # but for some reason it can't find elements by their ID, causing the tests
+  # to fail.
+  # - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  #     sudo safaridriver --enable;
+  #     SELENIUM_BROWSERS="firefox chrome safari";
+  #   else
+  #     SELENIUM_BROWSERS="firefox chrome";
+  #   fi
   - pushd selenium && make nuget && make && $XVFB_RUN make TEST_OPTIONS="--no-build-app --color --browsers $SELENIUM_BROWSERS" run && popd
   # Run SonarCloud, but only on Linux.
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ ! -z "$SONARCLOUD_KEY" ]; then sonar-scanner; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo pip3 install pygithub; fi
   # Install gulp.
   - npm install -g gulp
+  # Install serve, which we'll need for running the Selenium tests.
+  - npm install -g serve@6.5.3
   # Install npm dependencies.
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     token:
       secure: $SONARCLOUD_KEY
   firefox: "latest"
+  chrome: stable
   apt:
     packages:
       # Install pip3 so we can install PyGitHub.
@@ -57,7 +58,7 @@ script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then XVFB_RUN=xvfb-run; fi
   - $XVFB_RUN gulp test
   # Run the Selenium tests.
-  - pushd selenium && make nuget && make && $XVFB_RUN make TEST_OPTIONS="--no-build-app" run && popd
+  - pushd selenium && make nuget && make && $XVFB_RUN make TEST_OPTIONS="--no-build-app --browsers firefox chrome" run && popd
   # Run SonarCloud, but only on Linux.
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ ! -z "$SONARCLOUD_KEY" ]; then sonar-scanner; fi
   # Deploy a nightly build when all tests are successful for a master branch commit.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,8 @@ install:
   - npm install
   # Install gulp.
   - npm install -g gulp
+  # Install serve for running the Selenium tests.
+  - npm install -g serve@6.5.3
 
 # Build scripts. These run after installation.
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,9 +21,13 @@ install:
   - npm install -g gulp
   # Install serve for running the Selenium tests.
   - npm install -g serve@6.5.3
+  # Install this to keep node from running out of memory.
+  - npm install -g increase-memory-limit
 
 # Build scripts. These run after installation.
 build_script:
+  # Increase the memory limit before building.
+  - increase-memory-limit
   # Compile sources.
   - gulp lint build build-test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ build_script:
 test_script:
   # Run tests.
   - gulp test
-  # Host UnSHACLed so we can run the Selenium tests.
-  - start /B serve -s build -p 8080
   # Run the Selenium tests.
-  - pushd selenium && run-ci.bat https://localhost:8080/index.html && popd
+  - start /b serve -s build -p 8080 &&
+    pushd selenium && run-ci.bat https://localhost:8080/index.html && popd &&
+    taskkill /F /IM serve /T

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,5 +31,7 @@ build_script:
 test_script:
   # Run tests.
   - gulp test
-  # Run Selenium tests.
-  - pushd selenium && run-ci.bat && popd
+  # Host UnSHACLed so we can run the Selenium tests.
+  - start /B serve -s build -p 8080
+  # Run the Selenium tests.
+  - pushd selenium && run-ci.bat https://localhost:8080/index.html && popd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,13 +21,9 @@ install:
   - npm install -g gulp
   # Install serve for running the Selenium tests.
   - npm install -g serve@6.5.3
-  # Install this to keep node from running out of memory.
-  - npm install -g increase-memory-limit
 
 # Build scripts. These run after installation.
 build_script:
-  # Increase the memory limit before building.
-  - increase-memory-limit
   # Compile sources.
   - gulp lint build build-test
 
@@ -35,7 +31,3 @@ build_script:
 test_script:
   # Run tests.
   - gulp test
-  # Run the Selenium tests.
-  - start /b serve -s build -p 8080 &&
-    pushd selenium && run-ci.bat http://localhost:8080/index.html && popd &
-    taskkill /F /IM serve /T

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,5 +33,5 @@ test_script:
   - gulp test
   # Run the Selenium tests.
   - start /b serve -s build -p 8080 &&
-    pushd selenium && run-ci.bat https://localhost:8080/index.html && popd &&
+    pushd selenium && run-ci.bat http://localhost:8080/index.html && popd &
     taskkill /F /IM serve /T

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,5 +29,5 @@ build_script:
 test_script:
   # Run tests.
   - gulp test
-  # Run Selenium tests. TODO: get URL to index.html right on Windows.
-  # - pushd selenium && run-ci.bat && popd
+  # Run Selenium tests.
+  - pushd selenium && run-ci.bat && popd

--- a/selenium/Assert.cs
+++ b/selenium/Assert.cs
@@ -1,3 +1,5 @@
+using System;
+using OpenQA.Selenium;
 using Pixie;
 using Pixie.Markup;
 
@@ -56,6 +58,25 @@ namespace SeleniumTests
         public static void IsFalse(bool condition)
         {
             IsFalse(condition, "condition was true.");
+        }
+
+        /// <summary>
+        /// Asserts that a value cannot be <c>null</c>.
+        /// </summary>
+        /// <param name="value">The value to check.</param>
+        /// <param name="valueName">The name of the value to check.</param>
+        public static void IsNotNull(object value, string valueName)
+        {
+            IsTrue(
+                value != null,
+                Quotation.QuoteEvenInBold(
+                    "expected a non-",
+                    "null",
+                    " value for ",
+                    valueName,
+                    ", but got ",
+                    "null",
+                    " anyway."));
         }
 
         /// <summary>

--- a/selenium/Assert.cs
+++ b/selenium/Assert.cs
@@ -32,7 +32,7 @@ namespace SeleniumTests
         /// </param>
         public static void IsTrue(bool condition)
         {
-            IsTrue(condition, "condition was false.");
+            IsTrue(condition, "condition was unexpectedly false.");
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace SeleniumTests
         /// </param>
         public static void IsFalse(bool condition)
         {
-            IsFalse(condition, "condition was true.");
+            IsFalse(condition, "condition was unexpectedly true.");
         }
 
         /// <summary>

--- a/selenium/Options.cs
+++ b/selenium/Options.cs
@@ -45,6 +45,8 @@ namespace SeleniumTests
                     "Chooses which browsers to use for running the tests. " +
                     "Permissible values are ",
                     "firefox",
+                    ", ",
+                    "safari",
                     " and ",
                     "chrome",
                     ". By default, only ",

--- a/selenium/Options.cs
+++ b/selenium/Options.cs
@@ -70,6 +70,22 @@ namespace SeleniumTests
                 "no URL is specified.");
 
         /// <summary>
+        /// The 'color' option, which tells the test runner to print
+        /// colors even when it thinks it shouldn't.
+        /// </summary>
+        public static readonly Option Color =
+            new FlagOption(
+                OptionForm.Long("color"),
+                OptionForm.Long("no-color"),
+                false)
+            .WithDescription(
+                "Colorize the output. The positive form forces the " +
+                "use of ANSI color codes, the negative form disables " +
+                "output colors altogether. By default, the colorization " +
+                "of the output is decided based on the terminal in use, " +
+                "the operating system and whether output is redirected or not.");
+
+        /// <summary>
         /// The 'print-app-url' option, which makes the test runner
         /// print the URL to 'index.html' just prior to running the
         /// tests.
@@ -92,6 +108,7 @@ namespace SeleniumTests
         {
             BuildApplication,
             Browsers,
+            Color,
             Help,
             PrintApplicationUrl
         };

--- a/selenium/Program.cs
+++ b/selenium/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/selenium/Program.cs
+++ b/selenium/Program.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Firefox;
+using OpenQA.Selenium.Safari;
 using OpenQA.Selenium.Support.UI;
 using Pixie;
 using Pixie.Markup;
@@ -168,6 +169,16 @@ namespace SeleniumTests
                     options.SetLoggingPreference(LogType.Browser, LogLevel.Off);
                     options.SetLoggingPreference(LogType.Driver, LogLevel.Off);
                     return new ChromeDriver(options);
+                }
+            },
+            {
+                "safari",
+                () =>
+                {
+                    var options = new SafariOptions();
+                    options.SetLoggingPreference(LogType.Browser, LogLevel.Off);
+                    options.SetLoggingPreference(LogType.Driver, LogLevel.Off);
+                    return new SafariDriver(options);
                 }
             }
         };

--- a/selenium/Program.cs
+++ b/selenium/Program.cs
@@ -277,7 +277,7 @@ namespace SeleniumTests
                         bool success = testCase.Run(driver, builder.Key, log);
 
                         completedTestCases++;
-                        double percentage = 100 * completedTestCases / testCaseCount;
+                        var percentage = 100.0 * completedTestCases / testCaseCount;
 
                         // Print a fancy progress message.
                         progressLog.Log(

--- a/selenium/Program.cs
+++ b/selenium/Program.cs
@@ -356,7 +356,7 @@ namespace SeleniumTests
                         "cannot host",
                         Quotation.QuoteEvenInBold(
                             "expected ",
-                            "serve",
+                            procName,
                             " to reply with ",
                             expectedServerOutput,
                             " but instead it said ",

--- a/selenium/Program.cs
+++ b/selenium/Program.cs
@@ -149,12 +149,26 @@ namespace SeleniumTests
         {
             {
                 "firefox",
-                () => new FirefoxDriver(
-                    new FirefoxOptions { LogLevel = FirefoxDriverLogLevel.Fatal })
+                () =>
+                {
+                    var options = new FirefoxOptions { LogLevel = FirefoxDriverLogLevel.Fatal };
+                    options.SetLoggingPreference(LogType.Browser, LogLevel.Off);
+                    options.SetLoggingPreference(LogType.Driver, LogLevel.Off);
+                    options.SetLoggingPreference(LogType.Server, LogLevel.Off);
+                    options.SetLoggingPreference(LogType.Profiler, LogLevel.Off);
+                    options.SetLoggingPreference(LogType.Client, LogLevel.Off);
+                    return new FirefoxDriver(options);
+                }
             },
             {
                 "chrome",
-                () => new ChromeDriver()
+                () =>
+                {
+                    var options = new ChromeOptions();
+                    options.SetLoggingPreference(LogType.Browser, LogLevel.Off);
+                    options.SetLoggingPreference(LogType.Driver, LogLevel.Off);
+                    return new ChromeDriver(options);
+                }
             }
         };
 

--- a/selenium/Program.cs
+++ b/selenium/Program.cs
@@ -108,7 +108,7 @@ namespace SeleniumTests
                                 " failed to launch; do you have ",
                                 procName,
                                 " installed? If not, try ",
-                                "npm install -g " + procName,
+                                "npm install -g " + procName + "@6.5.3",
                                 ".")));
                     return 1;
                 }

--- a/selenium/SeleniumTests.csproj
+++ b/selenium/SeleniumTests.csproj
@@ -36,10 +36,10 @@
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="Pixie">
-      <HintPath>packages\Pixie.0.1.4\lib\net45\Pixie.dll</HintPath>
+      <HintPath>packages\Pixie.0.1.5\lib\net45\Pixie.dll</HintPath>
     </Reference>
     <Reference Include="Pixie.Terminal">
-      <HintPath>packages\Pixie.0.1.4\lib\net45\Pixie.Terminal.dll</HintPath>
+      <HintPath>packages\Pixie.0.1.5\lib\net45\Pixie.Terminal.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/selenium/Tests/SanityChecks.cs
+++ b/selenium/Tests/SanityChecks.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using OpenQA.Selenium;
 
 namespace SeleniumTests.Tests
 {
@@ -15,13 +16,27 @@ namespace SeleniumTests.Tests
                     Assert.AreEqual(driver.Title, "UnSHACLed Editor");
                 });
 
+        public static readonly TestCase AboutWorks =
+            new TestCase(
+                "About page can be accessed",
+                (driver, log) =>
+                {
+                    // Grab the 'about' navbar item.
+                    var elem = driver.FindElement(By.Id("navbar-item-about"));
+                    // Click it.
+                    elem.Click();
+                    // Check that we're at '#/about'.
+                    Assert.IsTrue(driver.Url.EndsWith("#/about"));
+                });
+
         /// <summary>
         /// A list of all sanity check tests.
         /// </summary>
         public static readonly IEnumerable<TestCase> All =
             new[]
         {
-            CheckTitle
+            CheckTitle,
+            AboutWorks
         };
     }
 }

--- a/selenium/Tests/SanityChecks.cs
+++ b/selenium/Tests/SanityChecks.cs
@@ -22,7 +22,7 @@ namespace SeleniumTests.Tests
                 (driver, log) =>
                 {
                     // Grab the 'about' navbar item.
-                    var elem = driver.FindElement(By.Id("navbar-item-about"));
+                    var elem = driver.FindElement(By.Id("navbarItemAbout"));
                     // Click it.
                     elem.Click();
                     // Check that we're at '#/about'.

--- a/selenium/Tests/SanityChecks.cs
+++ b/selenium/Tests/SanityChecks.cs
@@ -25,8 +25,8 @@ namespace SeleniumTests.Tests
                     var elem = driver.FindElement(By.Id("navbarItemAbout"));
                     // Click it.
                     elem.Click();
-                    // Check that we're at '#/about'.
-                    Assert.IsTrue(driver.Url.EndsWith("#/about"));
+                    // Check that we're at '/about'.
+                    Assert.IsTrue(driver.Url.EndsWith("/about"));
                 });
 
         /// <summary>

--- a/selenium/Tests/SanityChecks.cs
+++ b/selenium/Tests/SanityChecks.cs
@@ -25,8 +25,8 @@ namespace SeleniumTests.Tests
                     var elem = driver.FindElement(By.Id("navbarItemAbout"));
                     // Click it.
                     elem.Click();
-                    // Check that we're at '/about'.
-                    Assert.IsTrue(driver.Url.EndsWith("/about"));
+                    // Check that we're at '#/about'.
+                    Assert.IsTrue(driver.Url.EndsWith("#/about"));
                 });
 
         /// <summary>

--- a/selenium/packages.config
+++ b/selenium/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pixie" version="0.1.4" targetFramework="net45" />
+  <package id="Pixie" version="0.1.5" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="3.11.2" targetFramework="net45" />
   <package id="Selenium.WebDriver.ChromeDriver" version="2.38.0.1" targetFramework="net45" />
   <package id="Selenium.WebDriver.GeckoDriver" version="0.20.1" targetFramework="net45" />

--- a/selenium/run-ci.bat
+++ b/selenium/run-ci.bat
@@ -1,3 +1,3 @@
 nuget restore
 msbuild selenium.sln
-bin\Debug\selenium-tests.exe --no-build-app --print-app-url
+bin\Debug\selenium-tests.exe %1 --no-build-app --print-app-url

--- a/selenium/run-ci.bat
+++ b/selenium/run-ci.bat
@@ -1,3 +1,3 @@
 nuget restore
 msbuild selenium.sln
-bin\Debug\selenium-tests.exe %1 --no-build-app --print-app-url
+bin\Debug\selenium-tests.exe %1 --no-build-app --print-app-url --browsers firefox chrome

--- a/src/components/navbarHome.tsx
+++ b/src/components/navbarHome.tsx
@@ -23,7 +23,7 @@ class Navbar extends React.Component<any, any> {
                     <Menu.Item
                         as={Link}
                         to="/about"
-                        id="navbar-item-about"
+                        id="navbarItemAbout"
                         style={{color: 'white'}}
                     >
                         About

--- a/src/components/navbarHome.tsx
+++ b/src/components/navbarHome.tsx
@@ -23,6 +23,7 @@ class Navbar extends React.Component<any, any> {
                     <Menu.Item
                         as={Link}
                         to="/about"
+                        id="navbar-item-about"
                         style={{color: 'white'}}
                     >
                         About


### PR DESCRIPTION
This pull request proposes lots of (small) improvements to the Selenium test runner and CI setup, including:
  * Chrome tests run during CI builds,
  * `--browser safari` is supported, but not yet enabled for CI builds because somehow Safari won't find an element by its ID (this may warrant some further investigation),
  * Selenium test runner hosts UnSHACLed automatically,
  * Selenium test runner output in CI test logs is now colorized,
  * check marks/cross marks indicate failed tests.

Let's get this thing merged in. Just supporting Chrome will more than double our browser coverage.

Also, front-end/QA people: I'd really appreciate it if you could all add a Selenium test case or two. I don't know what exactly needs testing. You do.